### PR TITLE
KP-7947 Refactoring before adding new functionality

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MESSAGES CONTROL]
+# Black takes care of indenting
+disable=bad-continuation

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -46,7 +46,7 @@ class MSRecordParser:
             xpath, namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"}
         )[0]
 
-    def get_identifier(self, xpath):
+    def _get_identifier(self, xpath):
         """
         Retrieves the urn of the given XPath's url.
         """
@@ -67,16 +67,24 @@ class MSRecordParser:
         else:
             raise ValueError("No date found")
 
+    @property
+    def pid(self):
+        """
+        Return the PID for this record
+        """
+        try:
+            return self._get_identifier(
+                "//info:identificationInfo/info:identifier/text()",
+            )
+        except IndexError:
+            # no PID found
+            return None
+
     def check_pid_exists(self):
         """
         Only records with PIDs are relevant.
         """
-        urn = self.xml.xpath(
-            "//info:identificationInfo/info:identifier",
-            namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"},
-        )
-
-        return bool(urn)
+        return bool(self.pid)
 
     def _get_list_of_licenses(self):
         """
@@ -240,9 +248,7 @@ class MSRecordParser:
                     "url": "http://www.yso.fi/onto/okm-tieteenala/ta112",
                 }
             ],
-            "persistent_identifier": self.get_identifier(
-                "//info:identificationInfo/info:identifier/text()"
-            ),
+            "persistent_identifier": self.pid,
             "title": self._get_language_contents("//info:resourceName"),
             "description": self._get_language_contents("//info:description"),
             "modified": self._get_date(

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -26,7 +26,7 @@ class PMH_API:
 
         If no date is given, all records are fetched.
 
-        :param datetime: date (and time) string value
+        :param from_timestamp: timestamp string defining the start of the period
         """
         try:
             metadata_records = self.sickle.ListRecords(
@@ -37,7 +37,9 @@ class PMH_API:
                 }
             )
             for metadata_record in metadata_records:
-                yield metadata_record
+                yield MSRecordParser(
+                    etree.fromstring(etree.tostring(metadata_record.xml))
+                )
         except NoRecordsMatch:
             return
 
@@ -48,14 +50,9 @@ class PMH_API:
         :return: List of PIDs as strings
         """
         metashare_pids = []
-        for metadata_content in self.fetch_records():
-            lxml_record = etree.fromstring(etree.tostring(metadata_content.xml))
-            metadata_record = MSRecordParser(lxml_record)
-            if (
-                metadata_record.check_pid_exists()
-                and metadata_record.check_resourcetype_corpus()
-            ):
-                pid = metadata_record.get_identifier(
+        for record in self.fetch_records():
+            if record.check_pid_exists() and record.check_resourcetype_corpus():
+                pid = record.get_identifier(
                     "//info:identificationInfo/info:identifier/text()"
                 )
                 metashare_pids.append(pid)

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -42,6 +42,14 @@ class PMH_API:
         except NoRecordsMatch:
             return
 
+    def fetch_corpora(self, from_timestamp=None):
+        """
+        Iterate over all corpora type records that have a PID
+        """
+        for record in self.fetch_records(from_timestamp=from_timestamp):
+            if record.check_pid_exists() and record.check_resourcetype_corpus():
+                yield record
+
     @property
     def corpus_pids(self):
         """
@@ -49,10 +57,9 @@ class PMH_API:
         :return: List of PIDs as strings
         """
         metashare_pids = []
-        for record in self.fetch_records():
-            if record.check_pid_exists() and record.check_resourcetype_corpus():
-                pid = record.get_identifier(
-                    "//info:identificationInfo/info:identifier/text()"
-                )
-                metashare_pids.append(pid)
+        for corpus in self.fetch_corpora():
+            pid = corpus.get_identifier(
+                "//info:identificationInfo/info:identifier/text()"
+            )
+            metashare_pids.append(pid)
         return metashare_pids

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -58,8 +58,5 @@ class PMH_API:
         """
         metashare_pids = []
         for corpus in self.fetch_corpora():
-            pid = corpus.get_identifier(
-                "//info:identificationInfo/info:identifier/text()"
-            )
-            metashare_pids.append(pid)
+            metashare_pids.append(corpus.pid)
         return metashare_pids

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -2,6 +2,7 @@
 Fetch data from an OAI-PMH API of Metashare
 """
 
+from copy import deepcopy
 from lxml import etree
 from sickle import Sickle
 from sickle.oaiexceptions import NoRecordsMatch
@@ -37,9 +38,7 @@ class PMH_API:
                 }
             )
             for metadata_record in metadata_records:
-                yield MSRecordParser(
-                    etree.fromstring(etree.tostring(metadata_record.xml))
-                )
+                yield MSRecordParser(deepcopy(metadata_record.xml))
         except NoRecordsMatch:
             return
 

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -41,24 +41,19 @@ def last_harvest_date(filename):
         return None
 
 
-def records_to_dict(date_time=None, url="https://kielipankki.fi/md_api/que"):
+def metashare_corpora_to_dict(date_time=None, url="https://kielipankki.fi/md_api/que"):
     """
-    Fetches metadata records since the last logged harvest. If date is missing, all records are
+    Fetches corpora added since the last logged harvest. If date is missing, all records are
     fetched.
     :param: date_time: date and time value in format that OAI PMH reads
     :param url: string value of a url
     :return: list of mapped Metashare records (dictionaries)
     """
     api = PMH_API(url)
-    metashare_records = api.fetch_records(from_timestamp=date_time)
 
     mapped_records_list = []
-    for metashare_record in metashare_records:
-        if (
-            metashare_record.check_pid_exists()
-            and metashare_record.check_resourcetype_corpus()
-        ):
-            mapped_records_list.append(metashare_record.to_dict())
+    for record in api.fetch_records(from_timestamp=date_time):
+        mapped_records_list.append(record.to_dict())
     return mapped_records_list
 
 
@@ -100,7 +95,7 @@ def main(log_file):
 
     harvested_date = last_harvest_date(log_file)
     logger_harvester.info("Started")
-    send_data_to_metax(records_to_dict(harvested_date))
+    send_data_to_metax(metashare_corpora_to_dict(harvested_date))
     if harvested_date:
         logger_harvester.info("Success, records harvested since %s", harvested_date)
     else:

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -78,15 +78,6 @@ def send_data_to_metax(mapped_records):
             metax_api.create_record(mapped_record)
 
 
-def collect_metax_pids():
-    """
-    Fetches all existing PIDs in Kielipankki catalog records in Metax.
-    :return: List of PIDs as strings
-    """
-    metax_api = MetaxAPI()
-    return metax_api.datacatalog_record_pids()
-
-
 def sync_deleted_records(metashare_pids, metax_pids):
     """
     Compares record PIDs fetched from Kielipankki and Metax. Any records not existing in
@@ -107,6 +98,7 @@ def main(log_file):
     :param log_file: log file where harvest dates are logged
     """
     metashare_api = PMH_API("https://kielipankki.fi/md_api/que")
+    metax_api = MetaxAPI()
 
     harvested_date = last_harvest_date(log_file)
     logger_harvester.info("Started")
@@ -116,7 +108,7 @@ def main(log_file):
     else:
         logger_harvester.info("Success, all records harvested")
 
-    sync_deleted_records(metashare_api.corpus_pids, collect_metax_pids())
+    sync_deleted_records(metashare_api.corpus_pids, metax_api.datacatalog_record_pids())
 
 
 if __name__ == "__main__":

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -41,20 +41,6 @@ def last_harvest_date(filename):
         return None
 
 
-def sync_deleted_records(metashare_pids, metax_pids):
-    """
-    Compares record PIDs fetched from Kielipankki and Metax. Any records not existing in
-    Metashare (anymore) are deleted from Metax as well.
-    :param metashare_pids: List of PIDs as strings
-    :param metax_pids: List of PIDs as strings
-    """
-    metax_pids_set = set(metax_pids)
-    pids_not_in_metashare = metax_pids_set.difference(set(metashare_pids))
-    metax_api = MetaxAPI()
-    for pid in pids_not_in_metashare:
-        metax_api.delete_record(metax_api.record_id(pid))
-
-
 def main(log_file):
     """
     Runs the whole pipeline of fetching data since last harvest and sending it to Metax.
@@ -74,7 +60,7 @@ def main(log_file):
     else:
         logger_harvester.info("Success, all records harvested")
 
-    sync_deleted_records(metashare_api.corpus_pids, metax_api.datacatalog_record_pids())
+    metax_api.delete_records_not_in(metashare_api.fetch_records())
 
 
 if __name__ == "__main__":

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -54,13 +54,11 @@ def records_to_dict(date_time=None, url="https://kielipankki.fi/md_api/que"):
 
     mapped_records_list = []
     for metashare_record in metashare_records:
-        lxml_record = etree.fromstring(etree.tostring(metashare_record.xml))
-        mapped_record = MSRecordParser(lxml_record)
         if (
-            mapped_record.check_pid_exists()
-            and mapped_record.check_resourcetype_corpus()
+            metashare_record.check_pid_exists()
+            and metashare_record.check_resourcetype_corpus()
         ):
-            mapped_records_list.append(mapped_record.to_dict())
+            mapped_records_list.append(metashare_record.to_dict())
     return mapped_records_list
 
 

--- a/metax_api.py
+++ b/metax_api.py
@@ -77,6 +77,21 @@ class MetaxAPI:
         result = self._make_request("GET", endpoint, params)
         return result["results"][0]["id"] if result["count"] == 1 else None
 
+    def send_record(self, record):
+        """
+        Create or udpate a record on Metax.
+
+        If a record with the same PID exists in Metax, its metadata is updated,
+        otherwise a new record is created.
+
+        :record: `MSRecordParser` object representing the metadata to be sent
+        """
+        metax_pid = self.record_id(record.pid)
+        if metax_pid:
+            self.update_record(metax_pid, record.to_dict())
+        else:
+            self.create_record(record.to_dict())
+
     def create_record(self, data):
         """
         Create a dataset record to Metax.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,8 +213,10 @@ def mock_pids_list_in_datacatalog_matching_metashare(
 
 
 @pytest.fixture
-def single_record_xml():
-    """Well-formed sample xml"""
+def metashare_single_record_xml():
+    """
+    Metashare ListRecords output that contains a single record.
+    """
     return _get_file_as_string("tests/test_data/kielipankki_record_sample.xml")
 
 
@@ -228,10 +230,10 @@ def kielipankki_api_url():
 
 @pytest.fixture
 def mock_pids_list_from_metashare(
-    shared_request_mocker, kielipankki_api_url, single_record_xml, dataset_pid
+    shared_request_mocker, kielipankki_api_url, metashare_single_record_xml, dataset_pid
 ):
     """
     Mock a list of PIDs fetched from Metashare records.
     """
-    shared_request_mocker.get(kielipankki_api_url, text=single_record_xml)
+    shared_request_mocker.get(kielipankki_api_url, text=metashare_single_record_xml)
     return [dataset_pid]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,11 +175,13 @@ def mock_delete_record(shared_request_mocker, metax_dataset_id, metax_base_url):
 
 
 @pytest.fixture
-def mock_pids_list_in_datacatalog(
+def mock_pids_in_datacatalog(
     shared_request_mocker, metax_base_url, kielipankki_datacatalog_id, dataset_pid
 ):
     """
     Mock a GET request to fetch all PIDs in a datacatalog.
+
+    :return: A set containing the PIDs corresponding to the mocked request
     """
     pid_data = {
         "results": [
@@ -192,11 +194,11 @@ def mock_pids_list_in_datacatalog(
         f"{metax_base_url}/datasets?data_catalog__id={kielipankki_datacatalog_id}&limit=100",
         json=pid_data,
     )
-    return [dataset_pid, "pid2"]
+    return {dataset_pid, "pid2"}
 
 
 @pytest.fixture
-def mock_pids_list_in_datacatalog_matching_metashare(
+def mock_pids_in_datacatalog_matching_metashare(
     shared_request_mocker, metax_base_url, kielipankki_datacatalog_id, dataset_pid
 ):
     """
@@ -212,7 +214,7 @@ def mock_pids_list_in_datacatalog_matching_metashare(
         f"{metax_base_url}/datasets?data_catalog__id={kielipankki_datacatalog_id}&limit=100",
         json=pid_data,
     )
-    return [dataset_pid]
+    return {dataset_pid}
 
 
 @pytest.fixture
@@ -359,4 +361,11 @@ def latest_harvest_timestamp():
 def basic_metashare_record():
     """Well-formed record sample of Kielipankki metadata."""
     with open("tests/test_data/kielipankki_record_sample.xml") as xmlfile:
+        return MSRecordParser(etree.fromstring(xmlfile.read()))
+
+
+@pytest.fixture
+def license_with_custom_url_record():
+    """A record containing lisence url in documentation elements."""
+    with open("tests/test_data/res_with_license_url.xml") as xmlfile:
         return MSRecordParser(etree.fromstring(xmlfile.read()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,6 +221,16 @@ def metashare_single_record_xml():
 
 
 @pytest.fixture
+def metashare_multiple_records_xml():
+    """
+    Metashare ListRecords output that contains a multiple records.
+    """
+    return _get_file_as_string(
+        "tests/test_data/kielipankki_record_sample_multiple_records.xml"
+    )
+
+
+@pytest.fixture
 def kielipankki_api_url():
     """
     The URL of the OAI-PMH API used in tests.
@@ -229,7 +239,7 @@ def kielipankki_api_url():
 
 
 @pytest.fixture
-def mock_pids_list_from_metashare(
+def mock_single_pid_list_from_metashare(
     shared_request_mocker, kielipankki_api_url, metashare_single_record_xml, dataset_pid
 ):
     """
@@ -237,3 +247,21 @@ def mock_pids_list_from_metashare(
     """
     shared_request_mocker.get(kielipankki_api_url, text=metashare_single_record_xml)
     return [dataset_pid]
+
+
+@pytest.fixture
+def mock_corpus_pid_list_from_metashare(
+    shared_request_mocker, kielipankki_api_url, metashare_multiple_records_xml
+):
+    """
+    Mock the record list to contain numerous resources, four of which are corpora.
+
+    :return: PIDs for the corpora
+    """
+    shared_request_mocker.get(kielipankki_api_url, text=metashare_multiple_records_xml)
+    return [
+        "urn.fi/urn:nbn:fi:lb-2017021609",
+        "urn.fi/urn:nbn:fi:lb-20140730196",
+        "urn.fi/urn:nbn:fi:lb-2018060403",
+        "urn.fi/urn:nbn:fi:lb-2019121004",
+    ]

--- a/tests/harvester/conftest.py
+++ b/tests/harvester/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from harvester.pmh_interface import PMH_API
+
+
+@pytest.fixture
+def pmh_api(kielipankki_api_url):
+    """
+    PMH_API for running tests
+    """
+    return PMH_API(kielipankki_api_url)

--- a/tests/harvester/conftest.py
+++ b/tests/harvester/conftest.py
@@ -8,4 +8,4 @@ def pmh_api(kielipankki_api_url):
     """
     PMH_API for running tests
     """
-    return PMH_API(kielipankki_api_url)
+    return PMH_API("https://kielipankki.fi/md_api/que")

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -1,0 +1,2 @@
+def test_pids(pmh_api, mock_pids_list_from_metashare):
+    assert pmh_api.corpus_pids == mock_pids_list_from_metashare

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -1,3 +1,42 @@
+import urllib
+
+
+def test_fetch_records_with_last_harvest_date(
+    pmh_api,
+    shared_request_mocker,
+    mock_metashare_get_single_record,
+    latest_harvest_timestamp,
+):
+    """
+    Ensure that fetching records from a given date produces the expected record and has
+    used the given start date in the request.
+    """
+    records = [
+        record.to_dict()
+        for record in pmh_api.fetch_records(from_timestamp=latest_harvest_timestamp)
+    ]
+    assert records == mock_metashare_get_single_record
+    assert (
+        urllib.parse.quote(latest_harvest_timestamp)
+        in shared_request_mocker.last_request.url
+    )
+
+
+def test_fetch_records_without_last_harvest_date(
+    pmh_api,
+    shared_request_mocker,
+    mock_metashare_get_single_record,
+    latest_harvest_timestamp,
+):
+    """
+    Ensure that fetching records without a given start date produces the expected record
+    and has not used the "from" parameter in the request.
+    """
+    records = [record.to_dict() for record in pmh_api.fetch_records()]
+    assert records == mock_metashare_get_single_record
+    assert "from=" not in shared_request_mocker.last_request.url
+
+
 def test_corpus_pids_returns_correct_pids(pmh_api, mock_corpus_pid_list_from_metashare):
     """
     Verify that PMH_API is able to fetch PIDs for corpora.

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -1,2 +1,8 @@
-def test_pids(pmh_api, mock_pids_list_from_metashare):
-    assert pmh_api.corpus_pids == mock_pids_list_from_metashare
+def test_corpus_pids_returns_correct_pids(pmh_api, mock_corpus_pid_list_from_metashare):
+    """
+    Verify that PMH_API is able to fetch PIDs for corpora.
+
+    The test data has non-corpora resources too, but those must not be present in the
+    returned PIDs.
+    """
+    assert pmh_api.corpus_pids == mock_corpus_pid_list_from_metashare

--- a/tests/test_data/kielipankki_no_records.xml
+++ b/tests/test_data/kielipankki_no_records.xml
@@ -1,0 +1,7 @@
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+<responseDate>2024-01-08T15:09:19Z</responseDate>
+<request metadataPrefix="info" verb="ListRecords" from="2023-09-08T14:34:16Z">https://kielipankki.fi/md_api/que</request>
+<error code="noRecordsMatch">
+The combination of the values of the from, until, set and metadataPrefix arguments results in an empty list
+</error>
+</OAI-PMH>

--- a/tests/test_data/kielipankki_record_sample_multiple_records.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_records.xml
@@ -1,0 +1,781 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2024-01-04T13:32:00Z</responseDate>
+  <request verb="ListRecords" metadataPrefix="info">https://kielipankki.fi/md_api/que</request>
+  <ListRecords>
+    <record>
+      <header>
+        <identifier>oai:kielipankki.fi:shf53fd0</identifier>
+        <datestamp>2022-09-02T10:41:46Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="fi">Silva Kiurun ajanilmausaineisto</resourceName>
+            <resourceName lang="en">Silva Kiuru's Time Expressions Corpus</resourceName>
+            <description lang="fi">Tämä suomen kielen ajanilmauksia käsittävä aineisto on koottu kaunokirjallisten alkuperäisteosten, käännösten, murreaineistojen ja muiden tekstien pohjalta.</description>
+            <description lang="en">This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.</description>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2017021609</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-unrestrictedUse</availability>
+            <licenceInfo>
+              <licence>underNegotiation</licence>
+              <licensor>
+                <organizationInfo>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <organizationInfo>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </distributionRightsHolder>
+            </licenceInfo>
+            <iprHolder>
+              <organizationInfo>
+                <organizationName lang="en">University of Helsinki</organizationName>
+                <organizationShortName lang="en">UHEL</organizationShortName>
+                <communicationInfo>
+                  <email>firstname.surname@helsinki.fi</email>
+                </communicationInfo>
+              </organizationInfo>
+            </iprHolder>
+          </distributionInfo>
+          <contactPerson xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <surname lang="en">Siiroinen</surname>
+            <givenName lang="en">Mari</givenName>
+            <sex>female</sex>
+            <communicationInfo>
+              <email>mari.siiroinen@helsinki.fi</email>
+              <country>Finland</country>
+            </communicationInfo>
+            <affiliation>
+              <organizationName lang="en">University of Helsinki</organizationName>
+              <departmentName lang="en">Department of Finnish, Finno-Ugrian and Scandinavian Studies</departmentName>
+              <communicationInfo>
+                <email>miia.rajala@helsinki.fi</email>
+                <url>http://www.helsinki.fi/fus/index.htm</url>
+                <country>Finland</country>
+              </communicationInfo>
+            </affiliation>
+          </contactPerson>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2017-02-15</metadataCreationDate>
+            <metadataCreator>
+              <surname lang="und">Bartis</surname>
+              <givenName lang="und">Imre</givenName>
+              <sex>male</sex>
+              <communicationInfo>
+                <email>imre.bartis@helsinki.fi</email>
+                <url>http://orcid.org/0000-0002-9455-8771</url>
+                <city>Helsinki</city>
+                <country>Finland</country>
+              </communicationInfo>
+              <position>Project Coordinator</position>
+            </metadataCreator>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageName>Finnish</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLanguageId>fi</metadataLanguageId>
+            <metadataLastDateUpdated>2017-02-15</metadataLastDateUpdated>
+          </metadataInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <corpusInfo>
+              <resourceType>corpus</resourceType>
+              <corpusMediaType>
+                <corpusTextInfo>
+                  <mediaType>text</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <modalityInfo>
+                    <modalityType>writtenLanguage</modalityType>
+                  </modalityInfo>
+                  <sizeInfo>
+                    <size>1</size>
+                    <sizeUnit>other</sizeUnit>
+                  </sizeInfo>
+                  <textFormatInfo>
+                    <mimeType>application/msword</mimeType>
+                  </textFormatInfo>
+                </corpusTextInfo>
+              </corpusMediaType>
+            </corpusInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+    <record>
+      <header>
+        <identifier>oai:kielipankki.fi:sh0f73e0</identifier>
+        <datestamp>2022-09-02T10:41:46Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="en">Argumentation and Argument Visualisation in Promoting Strategic Reading and Decision-making</resourceName>
+            <description lang="en">Corpus of upper secondary school students' think-aloud performances when searching the Internet for information; recordings and transcriptions; text files.</description>
+            <url>http://www.jyu.fi/coalition/</url>
+            <url>https://kitwiki.csc.fi/twiki/bin/view/FinCLARIN/FinClarinSiteJY</url>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-20140730196</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-restrictedUse</availability>
+            <licenceInfo>
+              <licence>underNegotiation</licence>
+              <licensor>
+                <personInfo>
+                  <surname lang="en">Kiili</surname>
+                  <givenName lang="en">Carita</givenName>
+                  <sex>female</sex>
+                  <communicationInfo>
+                    <email>carita.kiili@jyu.fi</email>
+                  </communicationInfo>
+                  <affiliation>
+                    <organizationName lang="fi">Jyväskylän yliopisto</organizationName>
+                    <organizationName lang="en">University of Jyväskylä</organizationName>
+                    <organizationShortName lang="en">JYU</organizationShortName>
+                    <departmentName lang="fi">Kielten laitos</departmentName>
+                    <departmentName lang="en">Department of Languages</departmentName>
+                    <communicationInfo>
+                      <email>registry@jyu.fi</email>
+                      <url>https://www.jyu.fi/en</url>
+                      <city>Jyväskylä</city>
+                      <country>Finland</country>
+                    </communicationInfo>
+                  </affiliation>
+                </personInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <personInfo>
+                  <surname lang="en">Kiili</surname>
+                  <givenName lang="en">Carita</givenName>
+                  <sex>female</sex>
+                  <communicationInfo>
+                    <email>carita.kiili@jyu.fi</email>
+                  </communicationInfo>
+                  <affiliation>
+                    <organizationName lang="fi">Jyväskylän yliopisto</organizationName>
+                    <organizationName lang="en">University of Jyväskylä</organizationName>
+                    <organizationShortName lang="en">JYU</organizationShortName>
+                    <departmentName lang="fi">Kielten laitos</departmentName>
+                    <departmentName lang="en">Department of Languages</departmentName>
+                    <communicationInfo>
+                      <email>registry@jyu.fi</email>
+                      <url>https://www.jyu.fi/en</url>
+                      <city>Jyväskylä</city>
+                      <country>Finland</country>
+                    </communicationInfo>
+                  </affiliation>
+                </personInfo>
+              </distributionRightsHolder>
+            </licenceInfo>
+            <iprHolder>
+              <personInfo>
+                <surname lang="en">Kiili</surname>
+                <givenName lang="en">Carita</givenName>
+                <sex>female</sex>
+                <communicationInfo>
+                  <email>carita.kiili@jyu.fi</email>
+                </communicationInfo>
+                <affiliation>
+                  <organizationName lang="fi">Jyväskylän yliopisto</organizationName>
+                  <organizationName lang="en">University of Jyväskylä</organizationName>
+                  <organizationShortName lang="en">JYU</organizationShortName>
+                  <departmentName lang="fi">Kielten laitos</departmentName>
+                  <departmentName lang="en">Department of Languages</departmentName>
+                  <communicationInfo>
+                    <email>registry@jyu.fi</email>
+                    <url>https://www.jyu.fi/en</url>
+                    <city>Jyväskylä</city>
+                    <country>Finland</country>
+                  </communicationInfo>
+                </affiliation>
+              </personInfo>
+            </iprHolder>
+          </distributionInfo>
+          <contactPerson xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <surname lang="en">Kiili</surname>
+            <givenName lang="en">Carita</givenName>
+            <sex>female</sex>
+            <communicationInfo>
+              <email>carita.kiili@jyu.fi</email>
+            </communicationInfo>
+            <affiliation>
+              <organizationName lang="fi">Jyväskylän yliopisto</organizationName>
+              <organizationName lang="en">University of Jyväskylä</organizationName>
+              <organizationShortName lang="en">JYU</organizationShortName>
+              <departmentName lang="fi">Kielten laitos</departmentName>
+              <departmentName lang="en">Department of Languages</departmentName>
+              <communicationInfo>
+                <email>registry@jyu.fi</email>
+                <url>https://www.jyu.fi/en</url>
+                <city>Jyväskylä</city>
+                <country>Finland</country>
+              </communicationInfo>
+            </affiliation>
+          </contactPerson>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2014-07-30</metadataCreationDate>
+            <metadataCreator>
+              <surname lang="en">Bartis</surname>
+              <givenName lang="en">Imre</givenName>
+              <sex>male</sex>
+              <communicationInfo>
+                <email>imre.bartis@helsinki.fi</email>
+                <url>http://orcid.org/0000-0002-9455-8771</url>
+                <city>Helsinki</city>
+                <country>Finland</country>
+              </communicationInfo>
+              <position>Project Coordinator</position>
+              <affiliation>
+                <organizationName lang="en">FIN-CLARIN</organizationName>
+                <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+                <departmentName lang="en">University of Helsinki</departmentName>
+                <communicationInfo>
+                  <email>finclarin@helsinki.fi</email>
+                  <url>http://www.helsinki.fi/fin-clarin</url>
+                  <address>PO Box 24 (Unioninkatu 40)</address>
+                  <zipCode>00014</zipCode>
+                  <city>University of Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLastDateUpdated>2014-07-30</metadataLastDateUpdated>
+          </metadataInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <corpusInfo>
+              <resourceType>corpus</resourceType>
+              <corpusMediaType>
+                <corpusTextInfo>
+                  <mediaType>text</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <sizeInfo>
+                    <size>1</size>
+                    <sizeUnit>other</sizeUnit>
+                  </sizeInfo>
+                </corpusTextInfo>
+                <corpusAudioInfo>
+                  <mediaType>audio</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <audioSizeInfo>
+                    <sizeInfo>
+                      <size>1</size>
+                      <sizeUnit>other</sizeUnit>
+                    </sizeInfo>
+                  </audioSizeInfo>
+                </corpusAudioInfo>
+              </corpusMediaType>
+            </corpusInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+    <record>
+      <header>
+        <identifier>oai:kielipankki.fi:sh41ac60</identifier>
+        <datestamp>2022-11-17T04:02:11Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="fi">Suomenkielinen OpenSubtitles 2017, Kielipankin Korp-versio</resourceName>
+            <resourceName lang="en">Finnish OpenSubtitles 2017, Kielipankki Korp Version</resourceName>
+            <description lang="fi">Aineisto kattaa Opensubtitles.org sivuston jakamat elokuvien ja tv-ohjelmien suomenkieliset tekstitykset. Aineisto on johdannainen
+monikielisestä Opensubtitles2018 korpuksesta (http://opus.nlpl.eu/OpenSubtitles2018.php). Aineisto on jaettu lähteisiin ja lauseisiin. Lauseet on morfosyntaktisesti jäsennetty käyttäen Turku Dependenssi jäsennintä (http://turkunlp.github.io/Finnish-dep-parser/).</description>
+            <description lang="en">The corpus is available in Kielipankki through the Interface Korp.
+The corpus contains Finnish subtitles for movies and TV-series from http://www.opensubtitles.org/ The corpus is a derivative of the [OPUS OpenSubtitles2018](http://opus.nlpl.eu/OpenSubtitles2018.php) multilingual corpus. Information on the material processing up to sentence splitting can be found in the original publication Lison &amp; Tiedemann (2016). The corpus has been tokenized and annotated with morpho-syntactic analysis produced with the [Turku Dependency Parser](http://turkunlp.github.io/Finnish-dep-parser/). P. Lison and J. Tiedemann, 2016, OpenSubtitles2016: Extracting Large Parallel Corpora from Movie and TV Subtitles. In Proceedings of the 10th International Conference on Language Resources and Evaluation (LREC 2016)</description>
+            <resourceShortName lang="en">opensub-fi-2017-korp</resourceShortName>
+            <url>http://urn.fi/urn:nbn:fi:lb-2018060404</url>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2018060403</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-unrestrictedUse</availability>
+            <licenceInfo>
+              <licence>CC-BY</licence>
+              <restrictionsOfUse>attribution</restrictionsOfUse>
+              <distributionAccessMedium>accessibleThroughInterface</distributionAccessMedium>
+              <licensor>
+                <personInfo>
+                  <surname lang="fi">Huovilainen</surname>
+                  <givenName lang="fi">Tatu</givenName>
+                  <sex>male</sex>
+                  <communicationInfo>
+                    <email>tatu.huovilainen@helsinki.fi</email>
+                  </communicationInfo>
+                  <affiliation>
+                    <organizationName lang="en">University of Helsinki</organizationName>
+                    <organizationShortName lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </affiliation>
+                </personInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <organizationInfo>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </distributionRightsHolder>
+            </licenceInfo>
+            <iprHolder>
+              <personInfo>
+                <surname lang="fi">Huovilainen</surname>
+                <givenName lang="fi">Tatu</givenName>
+                <sex>male</sex>
+                <communicationInfo>
+                  <email>tatu.huovilainen@helsinki.fi</email>
+                </communicationInfo>
+                <affiliation>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </affiliation>
+              </personInfo>
+            </iprHolder>
+          </distributionInfo>
+          <contactPerson xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <surname lang="en">FIN-CLARIN</surname>
+            <givenName lang="en">User support</givenName>
+            <communicationInfo>
+              <email>fin-clarin@helsinki.fi</email>
+            </communicationInfo>
+          </contactPerson>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2018-06-04</metadataCreationDate>
+            <metadataCreator>
+              <surname lang="en">Dieckmann</surname>
+              <givenName lang="en">Ute</givenName>
+              <sex>unknown</sex>
+              <communicationInfo>
+                <email>ute.dieckmann@helsinki.fi</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">FIN-CLARIN</organizationName>
+                <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+                <departmentName lang="en">University of Helsinki</departmentName>
+                <communicationInfo>
+                  <email>finclarin@helsinki.fi</email>
+                  <url>http://www.helsinki.fi/fin-clarin</url>
+                  <address>PO Box 24 (Unioninkatu 40)</address>
+                  <zipCode>00014</zipCode>
+                  <city>University of Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <metadataCreator>
+              <surname lang="en">Westerlund</surname>
+              <givenName lang="en">Hanna</givenName>
+              <communicationInfo>
+                <email>hanna.westerlund@helsinki.fi</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">FIN-CLARIN</organizationName>
+                <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+                <departmentName lang="en">University of Helsinki</departmentName>
+                <communicationInfo>
+                  <email>finclarin@helsinki.fi</email>
+                  <url>http://www.helsinki.fi/fin-clarin</url>
+                  <address>PO Box 24 (Unioninkatu 40)</address>
+                  <zipCode>00014</zipCode>
+                  <city>University of Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLastDateUpdated>2021-08-13</metadataLastDateUpdated>
+            <revision>Link to resource group page and attribution details added</revision>
+          </metadataInfo>
+          <resourceDocumentationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <documentation>
+              <documentUnstructured>CHANGE LOG 12.11.2019 Added Kielipankki Korp Version to the title</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>CHANGE LOG: 30.1.2020 Availability changed from Restricted to Unrestricted.</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>Resource group page: http://urn.fi/urn:nbn:fi:lb-2021081202</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>How to cite: https://www.kielipankki.fi/viittaus/?key=opensub-fi-2017-korp&amp;lang=en</documentUnstructured>
+            </documentation>
+          </resourceDocumentationInfo>
+          <resourceCreationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceCreator>
+              <personInfo>
+                <surname lang="fi">Huovilainen</surname>
+                <givenName lang="fi">Tatu</givenName>
+                <sex>male</sex>
+                <communicationInfo>
+                  <email>tatu.huovilainen@helsinki.fi</email>
+                </communicationInfo>
+                <affiliation>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreator>
+          </resourceCreationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>IsVariantFormOf</relationType>
+            <relatedResource>
+              <targetResourceNameURI>http://urn.fi/urn:nbn:fi:lb-2019110801</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <corpusInfo>
+              <resourceType>corpus</resourceType>
+              <corpusMediaType>
+                <corpusTextInfo>
+                  <mediaType>text</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <sizeInfo>
+                    <size>267645406</size>
+                    <sizeUnit>tokens</sizeUnit>
+                  </sizeInfo>
+                  <sizeInfo>
+                    <size>52002003</size>
+                    <sizeUnit>sentences</sizeUnit>
+                  </sizeInfo>
+                </corpusTextInfo>
+              </corpusMediaType>
+            </corpusInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+    <record>
+      <header>
+        <identifier>oai:kielipankki.fi:sh8b3620</identifier>
+        <datestamp>2022-09-02T10:41:46Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="en">Lingsoft Proofreader for ICT Language for Finnish</resourceName>
+            <description lang="fi">Erityisalojen tarkistimet ovat Lingsoftin ainutlaatuinen ja kustannuksia säästävä ratkaisu toimialojen sisäisen kielen tarkistamiseen. Lingsoft Proofreader for Finnish ICT Language tarkistaa ICT-terminologian Microsoft-tyylioppaan mukaisesti.</description>
+            <description lang="en">Lingsoft Proofreader for Finnish ICT Language checks ICT terminology in accordance with the Microsoft Style Guide.</description>
+            <url>http://www.lingsoft.fi/tuotteet/msstyle</url>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2014073096</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-restrictedUse</availability>
+            <licenceInfo>
+              <licence>underNegotiation</licence>
+              <fee>250,00 € + VAT 24 %</fee>
+              <licensor>
+                <organizationInfo>
+                  <organizationName lang="en">Lingsoft</organizationName>
+                  <communicationInfo>
+                    <email>etunimi.sukunimi@lingsoft.fi</email>
+                    <url>http://www.lingsoft.fi</url>
+                  </communicationInfo>
+                </organizationInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <personInfo>
+                  <surname lang="en">Contact</surname>
+                  <communicationInfo>
+                    <email>info@lingsoft.fi</email>
+                  </communicationInfo>
+                  <affiliation>
+                    <organizationName lang="en">Lingsoft</organizationName>
+                    <communicationInfo>
+                      <email>etunimi.sukunimi@lingsoft.fi</email>
+                      <url>http://www.lingsoft.fi</url>
+                    </communicationInfo>
+                  </affiliation>
+                </personInfo>
+              </distributionRightsHolder>
+              <userNature>commercial</userNature>
+            </licenceInfo>
+            <iprHolder>
+              <organizationInfo>
+                <organizationName lang="en">Lingsoft</organizationName>
+                <communicationInfo>
+                  <email>etunimi.sukunimi@lingsoft.fi</email>
+                  <url>http://www.lingsoft.fi</url>
+                </communicationInfo>
+              </organizationInfo>
+            </iprHolder>
+          </distributionInfo>
+          <contactPerson xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <surname lang="en">Contact</surname>
+            <givenName lang="en">-</givenName>
+            <communicationInfo>
+              <email>firstname.surname@lingsoft.fi</email>
+              <url>http://www.lingsoft.fi</url>
+            </communicationInfo>
+            <affiliation>
+              <organizationName lang="en">Lingsoft</organizationName>
+              <communicationInfo>
+                <email>etunimi.sukunimi@lingsoft.fi</email>
+                <url>http://www.lingsoft.fi</url>
+              </communicationInfo>
+            </affiliation>
+          </contactPerson>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2012-12-06</metadataCreationDate>
+            <metadataCreator>
+              <surname lang="en">Pöyhönen</surname>
+              <givenName lang="en">Saara</givenName>
+              <sex>female</sex>
+              <communicationInfo>
+                <email>saara.poyhonen@helsinki.fi</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">University of Helsinki</organizationName>
+                <organizationShortName lang="en">UHEL</organizationShortName>
+                <communicationInfo>
+                  <email>firstname.surname@helsinki.fi</email>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <originalMetadataLink>http://www.lingsoft.fi/tuotteet/msstyle</originalMetadataLink>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageName>Finnish</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLanguageId>fi</metadataLanguageId>
+            <metadataLastDateUpdated>2012-12-06</metadataLastDateUpdated>
+          </metadataInfo>
+          <usageInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <foreseenUseInfo>
+              <foreseenUse>humanUse</foreseenUse>
+              <useNLPSpecific>spellChecking</useNLPSpecific>
+            </foreseenUseInfo>
+            <actualUseInfo>
+              <actualUse>humanUse</actualUse>
+              <useNLPSpecific>spellChecking</useNLPSpecific>
+            </actualUseInfo>
+          </usageInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <toolServiceInfo>
+              <resourceType>toolService</resourceType>
+              <toolServiceType>tool</toolServiceType>
+              <toolServiceSubtype>Spell checker</toolServiceSubtype>
+              <languageDependent>true</languageDependent>
+              <inputInfo>
+                <mediaType>text</mediaType>
+                <modalityType>writtenLanguage</modalityType>
+                <languageName>Finnish</languageName>
+                <languageId>fi</languageId>
+              </inputInfo>
+              <outputInfo>
+                <mediaType>text</mediaType>
+                <modalityType>writtenLanguage</modalityType>
+                <languageName>Finnish</languageName>
+                <languageId>fi</languageId>
+              </outputInfo>
+            </toolServiceInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+    <record>
+      <header>
+        <identifier>oai:kielipankki.fi:sh48ab80</identifier>
+        <datestamp>2022-09-07T04:12:33Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="fi">Ylen suomenkielinen uutisarkisto 2011-2018, sekoitettu, Korp</resourceName>
+            <resourceName lang="en">Yle Finnish News Archive 2011-2018, scrambled, Korp</resourceName>
+            <description lang="en">The corpus, containing the articles from YLE https://yle.fi from 2011-2018  as scrambled sentences, is available at Korp.</description>
+            <resourceShortName lang="en">ylenews-fi-2011-2018-s-korp</resourceShortName>
+            <url>http://urn.fi/urn:nbn:fi:lb-2019121006</url>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2019121004</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-unrestrictedUse</availability>
+            <licenceInfo>
+              <licence>CC-BY</licence>
+              <restrictionsOfUse>attribution</restrictionsOfUse>
+              <distributionAccessMedium>accessibleThroughInterface</distributionAccessMedium>
+              <licensor>
+                <organizationInfo>
+                  <organizationName lang="fi">Yleisradio Oy</organizationName>
+                  <organizationName lang="en">Finnish Broadcasting Company (Yle)</organizationName>
+                  <organizationShortName lang="fi">Yle</organizationShortName>
+                  <communicationInfo>
+                    <email>yleinfo@yle.fi</email>
+                    <url>https://yle.fi/</url>
+                    <country>Finland</country>
+                  </communicationInfo>
+                </organizationInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <organizationInfo>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </distributionRightsHolder>
+            </licenceInfo>
+            <iprHolder>
+              <organizationInfo>
+                <organizationName lang="fi">Yleisradio Oy</organizationName>
+                <organizationName lang="en">Finnish Broadcasting Company (Yle)</organizationName>
+                <organizationShortName lang="fi">Yle</organizationShortName>
+                <communicationInfo>
+                  <email>yleinfo@yle.fi</email>
+                  <url>https://yle.fi/</url>
+                  <country>Finland</country>
+                </communicationInfo>
+              </organizationInfo>
+            </iprHolder>
+          </distributionInfo>
+          <contactPerson xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <surname lang="en">FIN-CLARIN</surname>
+            <givenName lang="en">User support</givenName>
+            <communicationInfo>
+              <email>fin-clarin@helsinki.fi</email>
+            </communicationInfo>
+          </contactPerson>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2019-12-12</metadataCreationDate>
+            <metadataCreator>
+              <surname lang="en">Jauhiainen</surname>
+              <givenName lang="en">Tommi</givenName>
+              <communicationInfo>
+                <email>firstname.lastname@helsinki.fi</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">University of Helsinki</organizationName>
+                <organizationShortName lang="en">UHEL</organizationShortName>
+                <communicationInfo>
+                  <email>firstname.surname@helsinki.fi</email>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLastDateUpdated>2019-12-12</metadataLastDateUpdated>
+          </metadataInfo>
+          <resourceDocumentationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <documentation>
+              <documentUnstructured>Resource group page http://urn.fi/urn:nbn:fi:lb-2021020901</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>How to cite: https://www.kielipankki.fi/viittaus/?key=ylenews-fi-2011-2018-s-korp&amp;lang=en</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>CHANGE LOG: 21.6.2020 restriction Attribution added.</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentInfo>
+                <documentType>other</documentType>
+                <title lang="fi">Lisenssi (Ylen uutisarkisto, sekoitetut virkkeet)</title>
+                <title lang="en">License (Yle News Archive, scrambled sentences)</title>
+                <editor>FIN-CLARIN</editor>
+                <url>http://urn.fi/urn:nbn:fi:lb-2022082901</url>
+              </documentInfo>
+            </documentation>
+          </resourceDocumentationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>isDerivedFrom</relationType>
+            <relatedResource>
+              <targetResourceNameURI>http://urn.fi/urn:nbn:fi:lb-2017070501</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>isVariantFormOf</relationType>
+            <relatedResource>
+              <targetResourceNameURI>http://urn.fi/urn:nbn:fi:lb-2019121003</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>isSourceOf</relationType>
+            <relatedResource>
+              <targetResourceNameURI>http://urn.fi/urn:nbn:fi:lb-2020021107</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>IsPartOf</relationType>
+            <relatedResource>
+              <targetResourceNameURI>Yle Finnish News Archive 2011-2021, scrambled, Korp http://urn.fi/urn:nbn:fi:lb-2022032205</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <corpusInfo>
+              <resourceType>corpus</resourceType>
+              <corpusMediaType>
+                <corpusTextInfo>
+                  <mediaType>text</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <sizeInfo>
+                    <size>207500221</size>
+                    <sizeUnit>tokens</sizeUnit>
+                  </sizeInfo>
+                  <sizeInfo>
+                    <size>18708231</size>
+                    <sizeUnit>sentences</sizeUnit>
+                  </sizeInfo>
+                </corpusTextInfo>
+              </corpusMediaType>
+            </corpusInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -5,12 +5,12 @@ import metadata_harvester_cli
 
 @pytest.fixture
 def single_record_to_dict(
-    shared_request_mocker, kielipankki_api_url, single_record_xml
+    shared_request_mocker, kielipankki_api_url, metashare_single_record_xml
 ):
     """
     A GET request that returns the XML data as a dictionary
     """
-    shared_request_mocker.get(kielipankki_api_url, text=single_record_xml)
+    shared_request_mocker.get(kielipankki_api_url, text=metashare_single_record_xml)
     yield [
         {
             "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -240,7 +240,7 @@ def test_collect_metax_pids(mock_pids_list_in_datacatalog):
 
 
 def test_sync_deleted_records_with_diffs(
-    mock_pids_list_from_metashare,
+    mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog,
     mock_metashare_record_found_in_datacatalog,
     mock_delete_record,
@@ -249,13 +249,13 @@ def test_sync_deleted_records_with_diffs(
     Test that when PIDs collected from Metax do not exist in Metashare, those records are deleted from Metax.
     """
     metadata_harvester_cli.sync_deleted_records(
-        mock_pids_list_from_metashare, mock_pids_list_in_datacatalog
+        mock_single_pid_list_from_metashare, mock_pids_list_in_datacatalog
     )
     assert mock_delete_record.call_count == 2
 
 
 def test_sync_deleted_records_no_diffs(
-    mock_pids_list_from_metashare,
+    mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog_matching_metashare,
     mock_delete_record,
 ):
@@ -263,7 +263,8 @@ def test_sync_deleted_records_no_diffs(
     Test that when PIDs collected from Metax and Metashare match, no DELETE requests are made.
     """
     metadata_harvester_cli.sync_deleted_records(
-        mock_pids_list_from_metashare, mock_pids_list_in_datacatalog_matching_metashare
+        mock_single_pid_list_from_metashare,
+        mock_pids_list_in_datacatalog_matching_metashare,
     )
     assert mock_delete_record.call_count == 0
 
@@ -274,7 +275,7 @@ def test_main_all_data_harvested_and_records_in_sync(
     single_record_to_dict,
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
-    mock_pids_list_from_metashare,
+    mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog_matching_metashare,
 ):
     """
@@ -302,7 +303,7 @@ def test_main_all_data_harvested_and_records_not_in_sync(
     single_record_to_dict,
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
-    mock_pids_list_from_metashare,
+    mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog,
     mock_metashare_record_found_in_datacatalog,
     mock_delete_record,
@@ -333,7 +334,7 @@ def test_main_new_records_harvested_since_date_and_records_in_sync(
     single_record_to_dict,
     create_test_log_file,
     caplog,
-    mock_pids_list_from_metashare,
+    mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog_matching_metashare,
     mock_delete_record,
     mock_metashare_record_not_found_in_datacatalog,
@@ -365,7 +366,7 @@ def test_main_changed_records_harvested_since_date_and_records_not_in_sync(
     single_record_to_dict,
     create_test_log_file,
     caplog,
-    mock_pids_list_from_metashare,
+    mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog,
     mock_delete_record,
 ):

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -72,36 +72,6 @@ def test_get_last_harvest_with_unsuccessful_harvest(
     assert harvested_date == "2023-09-08T14:34:16Z"
 
 
-def test_sync_deleted_records_with_diffs(
-    mock_single_pid_list_from_metashare,
-    mock_pids_list_in_datacatalog,
-    mock_metashare_record_found_in_datacatalog,
-    mock_delete_record,
-):
-    """
-    Test that when PIDs collected from Metax do not exist in Metashare, those records are deleted from Metax.
-    """
-    metadata_harvester_cli.sync_deleted_records(
-        mock_single_pid_list_from_metashare, mock_pids_list_in_datacatalog
-    )
-    assert mock_delete_record.call_count == 2
-
-
-def test_sync_deleted_records_no_diffs(
-    mock_single_pid_list_from_metashare,
-    mock_pids_list_in_datacatalog_matching_metashare,
-    mock_delete_record,
-):
-    """
-    Test that when PIDs collected from Metax and Metashare match, no DELETE requests are made.
-    """
-    metadata_harvester_cli.sync_deleted_records(
-        mock_single_pid_list_from_metashare,
-        mock_pids_list_in_datacatalog_matching_metashare,
-    )
-    assert mock_delete_record.call_count == 0
-
-
 def test_main_all_data_harvested_and_records_in_sync(
     mock_requests_post,
     mock_metashare_record_not_found_in_datacatalog,
@@ -109,7 +79,7 @@ def test_main_all_data_harvested_and_records_in_sync(
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
     mock_single_pid_list_from_metashare,
-    mock_pids_list_in_datacatalog_matching_metashare,
+    mock_pids_in_datacatalog_matching_metashare,
 ):
     """
     Check that when no successful harvest date is available (the log file does not have any successful harvests logged), all data is fetched from Kielipankki.
@@ -137,7 +107,7 @@ def test_main_all_data_harvested_and_records_not_in_sync(
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
     mock_single_pid_list_from_metashare,
-    mock_pids_list_in_datacatalog,
+    mock_pids_in_datacatalog,
     mock_metashare_record_found_in_datacatalog,
     mock_delete_record,
 ):
@@ -178,7 +148,7 @@ def test_main_new_records_harvested_since_date_and_records_in_sync(
     create_test_log_file,
     caplog,
     mock_single_pid_list_from_metashare,
-    mock_pids_list_in_datacatalog_matching_metashare,
+    mock_pids_in_datacatalog_matching_metashare,
     mock_delete_record,
     mock_metashare_record_not_found_in_datacatalog,
 ):
@@ -210,7 +180,7 @@ def test_main_changed_records_harvested_since_date_and_records_not_in_sync(
     create_test_log_file,
     caplog,
     mock_single_pid_list_from_metashare,
-    mock_pids_list_in_datacatalog,
+    mock_pids_in_datacatalog,
     mock_delete_record,
 ):
     """

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -231,14 +231,6 @@ def test_send_data_to_metax_no_records_put(shared_request_mocker, metax_base_url
     assert shared_request_mocker.call_count == 0
 
 
-def test_collect_metax_pids(mock_pids_list_in_datacatalog):
-    """
-    Test that a list of PIDs from Metax are returned.
-    """
-    pids = metadata_harvester_cli.collect_metax_pids()
-    assert pids == mock_pids_list_in_datacatalog
-
-
 def test_sync_deleted_records_with_diffs(
     mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog,

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -72,14 +72,16 @@ def test_get_last_harvest_with_unsuccessful_harvest(
     assert harvested_date == "2023-09-08T14:34:16Z"
 
 
+@pytest.mark.usefixtures(
+    "mock_metashare_record_not_found_in_datacatalog",
+    "mock_single_pid_list_from_metashare",
+    "mock_pids_in_datacatalog_matching_metashare",
+)
 def test_main_all_data_harvested_and_records_in_sync(
     mock_requests_post,
-    mock_metashare_record_not_found_in_datacatalog,
     mock_metashare_get_single_record,
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
-    mock_single_pid_list_from_metashare,
-    mock_pids_in_datacatalog_matching_metashare,
 ):
     """
     Check that when no successful harvest date is available (the log file does not have any successful harvests logged), all data is fetched from Kielipankki.
@@ -101,15 +103,17 @@ def test_main_all_data_harvested_and_records_in_sync(
     assert "Success, all records harvested" in caplog.text
 
 
+@pytest.mark.usefixtures(
+    "mock_single_pid_list_from_metashare",
+    "mock_pids_in_datacatalog",
+    "mock_metashare_record_found_in_datacatalog",
+    "mock_delete_record",
+)
 def test_main_all_data_harvested_and_records_not_in_sync(
     mock_requests_put,
     mock_metashare_get_single_record,
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
-    mock_single_pid_list_from_metashare,
-    mock_pids_in_datacatalog,
-    mock_metashare_record_found_in_datacatalog,
-    mock_delete_record,
 ):
     """
     Check that when no successful harvest date is available (the log file does not have
@@ -142,15 +146,17 @@ def test_main_all_data_harvested_and_records_not_in_sync(
     assert "Success, all records harvested" in caplog.text
 
 
+@pytest.mark.usefixtures(
+    "mock_single_pid_list_from_metashare",
+    "mock_pids_in_datacatalog_matching_metashare",
+    "mock_delete_record",
+    "mock_metashare_record_not_found_in_datacatalog",
+)
 def test_main_new_records_harvested_since_date_and_records_in_sync(
     mock_requests_post,
     mock_metashare_get_single_record,
     create_test_log_file,
     caplog,
-    mock_single_pid_list_from_metashare,
-    mock_pids_in_datacatalog_matching_metashare,
-    mock_delete_record,
-    mock_metashare_record_not_found_in_datacatalog,
 ):
     """
     Check that, when there is a successful harvest logged, new and updated records since that
@@ -173,15 +179,17 @@ def test_main_new_records_harvested_since_date_and_records_in_sync(
     assert "Success, records harvested since" in caplog.text
 
 
+@pytest.mark.usefixtures(
+    "mock_metashare_record_found_in_datacatalog",
+    "mock_single_pid_list_from_metashare",
+    "mock_pids_in_datacatalog",
+    "mock_delete_record",
+)
 def test_main_changed_records_harvested_since_date_and_records_not_in_sync(
     mock_requests_put,
-    mock_metashare_record_found_in_datacatalog,
     mock_metashare_get_single_record,
     create_test_log_file,
     caplog,
-    mock_single_pid_list_from_metashare,
-    mock_pids_in_datacatalog,
-    mock_delete_record,
 ):
     """
     Check that, when there is a successful harvest logged previously, new and updated

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -231,14 +231,6 @@ def test_send_data_to_metax_no_records_put(shared_request_mocker, metax_base_url
     assert shared_request_mocker.call_count == 0
 
 
-def test_collect_metashare_pids(mock_pids_list_from_metashare):
-    """
-    Test that a list of PIDs from Metashare records are returned.
-    """
-    pids = metadata_harvester_cli.collect_metashare_pids()
-    assert pids == mock_pids_list_from_metashare
-
-
 def test_collect_metax_pids(mock_pids_list_in_datacatalog):
     """
     Test that a list of PIDs from Metax are returned.

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -43,7 +43,7 @@ def single_record_to_dict(
     ]
 
 
-def test_records_to_dict_with_last_harvest_date(
+def test_metashare_corpora_to_dict_with_last_harvest_date(
     single_record_to_dict, create_test_log_file
 ):
     """
@@ -51,12 +51,12 @@ def test_records_to_dict_with_last_harvest_date(
     fetched).
     """
     date = metadata_harvester_cli.last_harvest_date(create_test_log_file)
-    result = metadata_harvester_cli.records_to_dict(date)
+    result = metadata_harvester_cli.metashare_corpora_to_dict(date)
     assert date == "2023-09-08T14:45:58Z"
     assert single_record_to_dict == result
 
 
-def test_records_to_dict_without_last_harvest_date(
+def test_metashare_corpora_to_dict_without_last_harvest_date(
     single_record_to_dict, create_test_log_file_with_unsuccessful_harvest
 ):
     """
@@ -65,7 +65,7 @@ def test_records_to_dict_without_last_harvest_date(
     date = metadata_harvester_cli.last_harvest_date(
         create_test_log_file_with_unsuccessful_harvest
     )
-    result = metadata_harvester_cli.records_to_dict(date)
+    result = metadata_harvester_cli.metashare_corpora_to_dict(date)
     assert date is None
     assert single_record_to_dict == result
 

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -2,76 +2,12 @@ import logging
 import pytest
 import metadata_harvester_cli
 
-
-@pytest.fixture
-def single_record_to_dict(
-    shared_request_mocker, kielipankki_api_url, metashare_single_record_xml
-):
-    """
-    A GET request that returns the XML data as a dictionary
-    """
-    shared_request_mocker.get(kielipankki_api_url, text=metashare_single_record_xml)
-    yield [
-        {
-            "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",
-            "language": [{"url": "http://lexvo.org/id/iso639-3/fin"}],
-            "field_of_science": [
-                {"url": "http://www.yso.fi/onto/okm-tieteenala/ta112"}
-            ],
-            "persistent_identifier": "urn.fi/urn:nbn:fi:lb-2016101210",
-            "title": {
-                "en": "Silva Kiuru's Time Expressions Corpus",
-                "fi": "Silva Kiurun ajanilmausaineisto",
-            },
-            "description": {
-                "en": "This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.",
-                "fi": "Tämä suomen kielen ajanilmauksia käsittävä aineisto on koottu kaunokirjallisten alkuperäisteosten, käännösten, murreaineistojen ja muiden tekstien pohjalta.",
-            },
-            "modified": "2017-02-15T00:00:00.000000Z",
-            "issued": "2017-02-15T00:00:00.000000Z",
-            "access_rights": {
-                "license": [
-                    {
-                        "url": "http://uri.suomi.fi/codelist/fairdata/license/code/undernegotiation"
-                    }
-                ],
-                "access_type": {
-                    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
-                },
-            },
-        }
-    ]
-
-
-def test_metashare_corpora_to_dict_with_last_harvest_date(
-    single_record_to_dict, create_test_log_file
-):
-    """
-    Test that fetching records based on a date in log file succeeds (only updated records are
-    fetched).
-    """
-    date = metadata_harvester_cli.last_harvest_date(create_test_log_file)
-    result = metadata_harvester_cli.metashare_corpora_to_dict(date)
-    assert date == "2023-09-08T14:45:58Z"
-    assert single_record_to_dict == result
-
-
-def test_metashare_corpora_to_dict_without_last_harvest_date(
-    single_record_to_dict, create_test_log_file_with_unsuccessful_harvest
-):
-    """
-    Test that fetching records without a log file succeeds (all records are fetched).
-    """
-    date = metadata_harvester_cli.last_harvest_date(
-        create_test_log_file_with_unsuccessful_harvest
-    )
-    result = metadata_harvester_cli.metashare_corpora_to_dict(date)
-    assert date is None
-    assert single_record_to_dict == result
+# Pylint does not understand fixture use
+# pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-def create_test_log_file(tmp_path):
+def create_test_log_file(tmp_path, latest_harvest_timestamp):
     """Create a temporary log file for testing and clean up afterwards."""
     # log_file = "harvester_test.log"
     log_file_data = [
@@ -79,7 +15,7 @@ def create_test_log_file(tmp_path):
         "2023-09-08 14:42:58,652 - INFO - Success, all records harvested\n"
         "2023-09-08 14:44:58,690 - INFO - Started\n"
         "2023-09-08 14:45:58,690 - INFO - Started\n"
-        "2023-09-08 14:45:58,956 - INFO - Success, records harvested since 2023-09-08T14:34:16Z\n"
+        "2023-09-08 14:45:58,956 - INFO - Success, records harvested since {latest_harvest_timestamp}\n"
     ]
     log_file = tmp_path / "harvester_test.log"
     with open(log_file, "w") as file:
@@ -136,101 +72,6 @@ def test_get_last_harvest_with_unsuccessful_harvest(
     assert harvested_date == "2023-09-08T14:34:16Z"
 
 
-def test_send_data_to_metax_single_new_record(
-    single_record_to_dict,
-    mock_metashare_record_not_found_in_datacatalog,
-    mock_requests_post,
-):
-    """
-    Check that creating one new metadata record works
-
-    This means that Metax is queried for existence of the PID (not found) and then a new
-    record is POSTed. We also check that the posted data corresponds to the record dict
-    passed to the function.
-    """
-    metadata_harvester_cli.send_data_to_metax(single_record_to_dict)
-
-    assert mock_requests_post.call_count == 2
-
-    expected_post_request = mock_requests_post.request_history[1]
-
-    assert expected_post_request.method == "POST"
-    assert expected_post_request.json() == single_record_to_dict[0]
-
-
-def test_send_data_to_metax_single_pre_existing_record(
-    single_record_to_dict,
-    mock_metashare_record_found_in_datacatalog,
-    mock_requests_put,
-):
-    """
-    Check that creating one new metadata record works
-
-    This means that Metax is queried for existence of the PID (found), fetches the Metax
-    ID for the record, and then a new record is PUT. We also check that the posted
-    data corresponds to the record dict passed to the function.
-    """
-    metadata_harvester_cli.send_data_to_metax(single_record_to_dict)
-
-    assert mock_requests_put.call_count == 3
-
-    expected_put_request = mock_requests_put.request_history[2]
-
-    assert expected_put_request.method == "PUT"
-    assert expected_put_request.json() == single_record_to_dict[0]
-
-
-def test_send_data_to_metax_multiple_records(
-    mock_metashare_record_not_found_in_datacatalog,
-    mock_requests_post,
-):
-    """
-    Check that send_data_to_metax can handle more than one record at once.
-
-    This test only covers totally new records, as other tests are assumed to ensure that
-    updating old records works. Thus we expect to see one GET (check whether the record
-    already exists in Metax) and one POST (add the new record) for each given item in
-    the metadata records. This test also checks that teach POST has unique data.
-    """
-    records = [
-        {"meta": "data", "persistent_identifier": "pid1"},
-        {"infor": "mation", "persistent_identifier": "pid2"},
-    ]
-    metadata_harvester_cli.send_data_to_metax(records)
-
-    assert mock_requests_post.call_count == 4
-
-    post_requests = mock_requests_post.request_history[1::2]
-    for post_request, record in zip(post_requests, records):
-        assert post_request.method == "POST"
-        assert (
-            post_request.json()["persistent_identifier"]
-            == record["persistent_identifier"]
-        )
-
-
-def test_send_data_to_metax_no_records_post(shared_request_mocker, metax_base_url):
-    """
-    Check that send_data_to_metax does not POST if en empty dictinary is passed to it.
-    """
-    records = []
-    metadata_harvester_cli.send_data_to_metax(records)
-    shared_request_mocker.post(metax_base_url)
-
-    assert shared_request_mocker.call_count == 0
-
-
-def test_send_data_to_metax_no_records_put(shared_request_mocker, metax_base_url):
-    """
-    Check that send_data_to_metax does not PUT if an empty dictionary is passed to it.
-    """
-    records = []
-    metadata_harvester_cli.send_data_to_metax(records)
-    shared_request_mocker.put(metax_base_url)
-
-    assert shared_request_mocker.call_count == 0
-
-
 def test_sync_deleted_records_with_diffs(
     mock_single_pid_list_from_metashare,
     mock_pids_list_in_datacatalog,
@@ -264,7 +105,7 @@ def test_sync_deleted_records_no_diffs(
 def test_main_all_data_harvested_and_records_in_sync(
     mock_requests_post,
     mock_metashare_record_not_found_in_datacatalog,
-    single_record_to_dict,
+    mock_metashare_get_single_record,
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
     mock_single_pid_list_from_metashare,
@@ -284,7 +125,7 @@ def test_main_all_data_harvested_and_records_in_sync(
     assert mock_requests_post.request_history[2].method == "POST"
     assert (
         mock_requests_post.request_history[2].json()["persistent_identifier"]
-        == single_record_to_dict[0]["persistent_identifier"]
+        == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
     assert "Success, all records harvested" in caplog.text
@@ -292,7 +133,7 @@ def test_main_all_data_harvested_and_records_in_sync(
 
 def test_main_all_data_harvested_and_records_not_in_sync(
     mock_requests_put,
-    single_record_to_dict,
+    mock_metashare_get_single_record,
     create_test_log_file_with_unsuccessful_harvest,
     caplog,
     mock_single_pid_list_from_metashare,
@@ -301,21 +142,31 @@ def test_main_all_data_harvested_and_records_not_in_sync(
     mock_delete_record,
 ):
     """
-    Check that when no successful harvest date is available (the log file does not have any successful harvests logged), all data is fetched from Kielipankki.
+    Check that when no successful harvest date is available (the log file does not have
+    any successful harvests logged), all data is fetched from Kielipankki.
 
-    The test also covers the situation where the record PID matches the ones in Metax so the data is PUT to Metax.
+    The test also covers the situation where the record PID matches the ones in Metax so
+    the data is PUT to Metax.
 
-    Finally, the records from both services are compared resulting in one non-matching PID. This non-matching record is then DELETEd from Metax.
+    Finally, the records from both services are compared resulting in one non-matching
+    PID. This non-matching record is then DELETEd from Metax.
+
+    Expected requests made during this test:
+    GET to fetch the records from Metashare (for adding new records)
+    GET to get the Metax PID (found)
+    PUT to to update the data in Metax
+    GET to fetch the records from Metashare (again, for deleted records this time)
+    GET to fetch the records from Metax (no overlap, so no further requests)
     """
 
     with caplog.at_level(logging.INFO):
         metadata_harvester_cli.main(create_test_log_file_with_unsuccessful_harvest)
 
-    assert mock_requests_put.call_count == 6
-    assert mock_requests_put.request_history[3].method == "PUT"
+    assert mock_requests_put.call_count == 5
+    assert mock_requests_put.request_history[2].method == "PUT"
     assert (
-        mock_requests_put.request_history[3].json()["persistent_identifier"]
-        == single_record_to_dict[0]["persistent_identifier"]
+        mock_requests_put.request_history[2].json()["persistent_identifier"]
+        == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
     assert "Success, all records harvested" in caplog.text
@@ -323,7 +174,7 @@ def test_main_all_data_harvested_and_records_not_in_sync(
 
 def test_main_new_records_harvested_since_date_and_records_in_sync(
     mock_requests_post,
-    single_record_to_dict,
+    mock_metashare_get_single_record,
     create_test_log_file,
     caplog,
     mock_single_pid_list_from_metashare,
@@ -346,7 +197,7 @@ def test_main_new_records_harvested_since_date_and_records_in_sync(
     assert mock_requests_post.request_history[2].method == "POST"
     assert (
         mock_requests_post.request_history[2].json()["persistent_identifier"]
-        == single_record_to_dict[0]["persistent_identifier"]
+        == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
     assert "Success, records harvested since" in caplog.text
@@ -355,7 +206,7 @@ def test_main_new_records_harvested_since_date_and_records_in_sync(
 def test_main_changed_records_harvested_since_date_and_records_not_in_sync(
     mock_requests_put,
     mock_metashare_record_found_in_datacatalog,
-    single_record_to_dict,
+    mock_metashare_get_single_record,
     create_test_log_file,
     caplog,
     mock_single_pid_list_from_metashare,
@@ -363,22 +214,90 @@ def test_main_changed_records_harvested_since_date_and_records_not_in_sync(
     mock_delete_record,
 ):
     """
-    Check that, when there is a successful harvest logged previously, new and updated records
-    are fetched from Kielipankki and then sent to Metax.
+    Check that, when there is a successful harvest logged previously, new and updated
+    records are fetched from Kielipankki and then sent to Metax.
 
     This test covers only changed records that are PUT to Metax.
 
-    Finally, the records from both services are compared resulting in one non-matching PID. This non-matching record is then DELETEd from Metax.
+    Finally, the records from both services are compared resulting in one non-matching
+    PID. This non-matching record is then DELETEd from Metax.
 
+    Expected requests made during this test:
+    GET to fetch the records from Metashare (for adding new records)
+    GET to get the Metax PID (found)
+    PUT to to update the data in Metax
+    GET to fetch the records from Metashare (again, for deleted records this time)
+    GET to fetch the records from Metax
+    GET to get the Metax PID for the record to be deleted
+    DELETE to delete the record
     """
     with caplog.at_level(logging.INFO):
         metadata_harvester_cli.main(create_test_log_file)
 
-    assert mock_requests_put.call_count == 8
-    assert mock_requests_put.request_history[3].method == "PUT"
+    assert mock_requests_put.call_count == 7
+    assert mock_requests_put.request_history[2].method == "PUT"
     assert (
-        mock_requests_put.request_history[3].json()["persistent_identifier"]
-        == single_record_to_dict[0]["persistent_identifier"]
+        mock_requests_put.request_history[2].json()["persistent_identifier"]
+        == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
     assert "Success, records harvested since" in caplog.text
+
+
+@pytest.mark.usefixtures(
+    "mock_metashare_get_multiple_records",
+    "mock_requests_post",
+    "mock_metashare_record_not_found_in_datacatalog",
+)
+def test_main_multiple_records(
+    shared_request_mocker,
+    create_test_log_file_with_unsuccessful_harvest,
+):
+    """
+    Check that multiple records are looped over properly.
+
+    This is verified by checking that there is one POST request for each corpus in
+    Metashare and no unexpected requests happened.
+
+    The requests we expect to see:
+    GET to fetch the records from Metashare (for adding new records)
+    For each corpus record (5 in test data):
+        GET to get Metax PID (not found)
+        POST to send the data to Metax
+    GET to fetch the records from Metashare (again, for deleted records this time)
+    GET to fetch the Metax PIDs for comparison (nothing to be deleted found)
+    """
+    metadata_harvester_cli.main(create_test_log_file_with_unsuccessful_harvest)
+
+    assert shared_request_mocker.call_count == 13
+    assert (
+        sum(
+            request.method == "POST"
+            for request in shared_request_mocker.request_history
+        )
+        == 5
+    )
+
+
+@pytest.mark.usefixtures(
+    "mock_metashare_get_no_new_records",
+    "mock_metashare_record_not_found_in_datacatalog",
+)
+def test_main_no_new_records(
+    shared_request_mocker,
+    create_test_log_file,
+):
+    """
+    Test that when there are no new records, the program moves directly to checking for
+    records pending removal
+
+
+    The requests we expect to see:
+    GET to fetch the records from Metashare (for adding new records, none found)
+    GET to fetch the records from Metashare (again, for deleted records this time, none
+        found)
+    GET to fetch the Metax PIDs for comparison (none found)
+    """
+    metadata_harvester_cli.main(create_test_log_file)
+    assert shared_request_mocker.call_count == 3
+    assert all(r.method == "GET" for r in shared_request_mocker.request_history)

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -116,12 +116,6 @@ def test_missing_license_record(missing_license_record):
     assert result == expected_result
 
 
-@pytest.fixture
-def license_with_custom_url_record():
-    """A record containing lisence url in documentation elements."""
-    return MSRecordParser(_get_file_as_lxml("tests/test_data/res_with_license_url.xml"))
-
-
 def test_license_custom_url_record(license_with_custom_url_record):
     """Test that license details and availability are mapped."""
     result = license_with_custom_url_record._map_access_rights()

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -37,11 +37,10 @@ def test_get_description(single_record):
     assert result == expected_result
 
 
-def test_get_identifier(single_record, dataset_pid):
-    """Check that a PID is returned."""
+def test_pid(single_record, dataset_pid):
+    """Check that the correct PID is returned."""
     record = MSRecordParser(single_record)
-    result = record.get_identifier("//info:identificationInfo/info:identifier/text()")
-    assert result == dataset_pid
+    assert record.pid == dataset_pid
 
 
 def test_get_modified_date(single_record):

--- a/tests/test_metax_api.py
+++ b/tests/test_metax_api.py
@@ -174,3 +174,55 @@ def test_datacatalog_dataset_record_pids(mock_pids_list_in_datacatalog, metax_ap
     """
     result = metax_api.datacatalog_record_pids()
     assert result == mock_pids_list_in_datacatalog
+
+
+@pytest.mark.usefixtures(
+    "mock_metashare_record_not_found_in_datacatalog",
+    "mock_requests_post",
+)
+def test_send_record(
+    shared_request_mocker,
+    metax_api,
+    basic_metashare_record,
+):
+    """
+    Check that creating one new metadata record works
+
+    This means that Metax is queried for existence of the PID (not found) and then a new
+    record is POSTed. We also check that the posted data corresponds to the record dict
+    passed to the function.
+    """
+    metax_api.send_record(basic_metashare_record)
+
+    assert shared_request_mocker.call_count == 2
+
+    expected_post_request = shared_request_mocker.request_history[1]
+
+    assert expected_post_request.method == "POST"
+    assert expected_post_request.json() == basic_metashare_record.to_dict()
+
+
+@pytest.mark.usefixtures(
+    "mock_metashare_record_found_in_datacatalog",
+    "mock_requests_put",
+)
+def test_send_data_to_metax_single_pre_existing_record(
+    shared_request_mocker,
+    metax_api,
+    basic_metashare_record,
+):
+    """
+    Check that creating one new metadata record works
+
+    This means that Metax is queried for existence of the PID (found), fetches the Metax
+    ID for the record, and then a new record is PUT. We also check that the posted
+    data corresponds to the record dict passed to the function.
+    """
+    metax_api.send_record(basic_metashare_record)
+
+    assert shared_request_mocker.call_count == 2
+
+    expected_put_request = shared_request_mocker.request_history[1]
+
+    assert expected_put_request.method == "PUT"
+    assert expected_put_request.json() == basic_metashare_record.to_dict()


### PR DESCRIPTION
I did some refactoring for the pre-existing code before implementing the actual new features in this ticket. The main goal was to limit the CLI module responsibilities so that it does not consider lower-level application logic. The lower level decision making and metadata manipulations were instead moved to the appropriate pre-existing class.

Some new tests were added to ensure that the new functionalities work, and some of the old tests and fixtures were edited, hopefully also improved.