### PR TITLE
KP-7947: API token from configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 *.log
 *.coverage
 *.sw?
+config/*
+!config/template.yml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kielipankki-Metax-bridge
 
-This tool enables fetching metadata records from META-SHARE via its OAI-PMH API. It transforms and maps XML data to Metax accepted JSON format and pushes the data to Metax. 
+This tool enables fetching metadata records from META-SHARE via its OAI-PMH API. It transforms and maps XML data to Metax accepted JSON format and pushes the data to Metax.
 
-Furthermore, the tool checks whether records' PIDs in Kielipankki OAI-PMH API match those in Metax. If there are extra PIDs in Metax, their records are deleted from Metax. 
+Furthermore, the tool checks whether records' PIDs in Kielipankki OAI-PMH API match those in Metax. If there are extra PIDs in Metax, their records are deleted from Metax.
 
 ## Running the program
 
@@ -10,9 +10,14 @@ Furthermore, the tool checks whether records' PIDs in Kielipankki OAI-PMH API ma
 ### Requirements
 This tool works with Python 3.8 together with pip and virtualenv installed. The rest of the requirements can be installed with ```pip install -r requirements.txt```.
 
+
 ### Run the whole pipeline
 
-```python metadata_harvester_cli.py```
+You can run the full havest process (fetch new records from Metashare, send them to Metax, and delete deleted records from Metax). This requires that you specify the path to the log file for logging timestamps for previous harvests and a configuration file that holds the API token for the Metax API. See `config/template.yml`.
+
+```
+python metadata_harvester_cli.py harvester.log config/config.yml
+```
 
 
 ## Development

--- a/config/template.yml
+++ b/config/template.yml
@@ -1,0 +1,2 @@
+---
+metax_api_token: filltokenhere

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -4,7 +4,10 @@ Main script for running metadata harvesting and sending it to Metax.
 
 import logging
 from datetime import datetime
+
+import click
 from lxml import etree
+
 from harvester.pmh_interface import PMH_API
 from harvester.metadata_parser import MSRecordParser
 from metax_api import MetaxAPI
@@ -18,15 +21,15 @@ file_handler_harvester.setFormatter(
 logger_harvester.addHandler(file_handler_harvester)
 
 
-def last_harvest_date(filename):
+def last_harvest_date(log_file_path):
     """This function gets the start time of last successful harvesting date and time from the log
     if found.
     :param filename: string value of a file name
     :return: date and time
     """
     try:
-        with open(filename, "r") as file:
-            lines = file.readlines()
+        with open(log_file_path, "r") as log_file:
+            lines = log_file.readlines()
 
             for i in range(len(lines) - 1, -1, -1):
                 if "success" in lines[i].lower():
@@ -36,12 +39,14 @@ def last_harvest_date(filename):
                             log_datetime_str, "%Y-%m-%d %H:%M:%S,%f"
                         )
                         return log_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
-        return None
+            return None
     except FileNotFoundError:
         return None
 
 
-def main(log_file):
+@click.command()
+@click.argument("log_file", type=click.Path(), default="harvester.log")
+def full_harvest(log_file):
     """
     Runs the whole pipeline of fetching data since last harvest and sending it to Metax.
     :param log_file: log file where harvest dates are logged
@@ -64,4 +69,4 @@ def main(log_file):
 
 
 if __name__ == "__main__":
-    main("harvester.log")
+    full_harvest()  # pylint: disable=no-value-for-parameter

--- a/metax_api.py
+++ b/metax_api.py
@@ -9,10 +9,13 @@ class MetaxAPI:
     An API client for interacting with the Metax V3 service.
     """
 
-    def __init__(self):
+    def __init__(self, api_token):
         self.logger = self._setup_logger()
         self.base_url = "https://metax-service.fd-staging.csc.fi/v3"
-        self.headers = {"Content-Type": "application/json"}
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Token {api_token}",
+        }
         self.catalog_id = "urn:nbn:fi:att:data-catalog-kielipankki"
         self.timeout = 30
 

--- a/metax_api.py
+++ b/metax_api.py
@@ -11,7 +11,7 @@ class MetaxAPI:
 
     def __init__(self, api_token):
         self.logger = self._setup_logger()
-        self.base_url = "https://metax-service.fd-staging.csc.fi/v3"
+        self.base_url = "https://metax.fd-rework.csc.fi/v3"
         self.headers = {
             "Content-Type": "application/json",
             "Authorization": f"Token {api_token}",
@@ -72,6 +72,7 @@ class MetaxAPI:
     def record_id(self, pid):
         """
         Get the UUID of a dataset record from Metax if such record exists.
+
         :param dataset pid: the persistent identifier of the record
         :return: the record identifier in Metax or None
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 sickle
 lxml
+PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+click
 sickle
 lxml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def shared_request_mocker():
 
 @pytest.fixture
 def metax_api():
-    return MetaxAPI()
+    return MetaxAPI(api_token="dummyapitoken")
 
 
 def _get_file_as_string(filename):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def _get_file_as_string(filename):
 @pytest.fixture
 def metax_base_url():
     """Metax API"""
-    return "https://metax-service.fd-staging.csc.fi/v3"
+    return "https://metax.fd-rework.csc.fi/v3"
 
 
 @pytest.fixture

--- a/tests/test_metax_api.py
+++ b/tests/test_metax_api.py
@@ -2,7 +2,20 @@ import logging
 import pytest
 import requests
 import requests_mock
-import metax_api
+
+from metax_api import MetaxAPI
+
+
+def test_api_token_in_headers(mock_requests_post):
+    """
+    Verify that the given API token is used when making requests.
+    """
+    metax = MetaxAPI("token_test_value")
+    metax.create_record({"dummy": "data"})
+    assert (
+        mock_requests_post.request_history[0].headers["Authorization"]
+        == "Token token_test_value"
+    )
 
 
 def test_record_id_pid_in_datacatalog(


### PR DESCRIPTION
Added YAML configuration file parsing and support for providing the Metax API token in it. The attempt was to make the error messages in case of malformed configuration file somewhat user friendly and to allow the later parts of the program trust that all required information is available if no errors were raised during configuration file parsing.

Gitignore is configured so that it is not easy to accidentally commit secrets from the config files: everything within the `config` directory is ignored, apart from the explicitly listed template.

Having the log file as a separate argument is not a long term solution: KP-7948 will put that into the configuration file (together with the now hard-coded metax API request log).