### PR TITLE
KP-7973 Fix Metax compatibility

### DIFF
--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -89,12 +89,10 @@ class MSRecordParser:
         """
         Retrieves all licenseInfo elements.
         """
-        license_elements_list = self.xml.xpath(
+        return self.xml.xpath(
             "//info:distributionInfo/info:licenceInfo",
             namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"},
         )
-        if license_elements_list:
-            return license_elements_list
 
     def check_resourcetype_corpus(self):
         """
@@ -194,6 +192,10 @@ class MSRecordParser:
     def _map_access_rights(self):
         """
         Retrieves and maps all license and access type information to a dictionary.
+
+        If any of the license elements found in the metadata do not have known specific
+        uri.suomi.fi mapping, the said license is skipped. If this would result in no
+        licenses being produced, the license is marked as "other".
         """
         license_package = {}
         license_mappings = {
@@ -217,14 +219,12 @@ class MSRecordParser:
         license_elements_list = self._get_list_of_licenses()
         license_list = []
 
-        if license_elements_list:
-            for license_element in license_elements_list:
-                license = self._get_license_information(
-                    license_element, license_mappings
-                )
-                if license:
-                    license_list.append(license)
-        else:
+        for license_element in license_elements_list:
+            license = self._get_license_information(license_element, license_mappings)
+            if license:
+                license_list.append(license)
+
+        if not license_list:
             license = {"url": license_mappings["other"]}
             license_list.append(license)
 

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -222,7 +222,8 @@ class MSRecordParser:
                 license = self._get_license_information(
                     license_element, license_mappings
                 )
-                license_list.append(license)
+                if license:
+                    license_list.append(license)
         else:
             license = {"url": license_mappings["other"]}
             license_list.append(license)

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -225,8 +225,7 @@ class MSRecordParser:
                 license_list.append(license)
 
         if not license_list:
-            license = {"url": license_mappings["other"]}
-            license_list.append(license)
+            license_list.append({"url": license_mappings["other"]})
 
         access_type = self._get_access_type()
 

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -253,7 +253,7 @@ class MSRecordParser:
             "modified": self._get_datetime(
                 "//info:metadataInfo/info:metadataLastDateUpdated/text()"
             ),
-            "issued": self._get_datetime(
+            "created": self._get_datetime(
                 "//info:metadataInfo/info:metadataCreationDate/text()"
             ),
             "access_rights": self._map_access_rights(),

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -54,15 +54,14 @@ class MSRecordParser:
         netloc, path = urlparse(identifier_url).netloc, urlparse(identifier_url).path
         return netloc + path
 
-    def _get_date(self, xpath):
+    def _get_datetime(self, xpath):
         """
-        Retrieves the date of the given XPath and returns it  appropriate date-time format.
-
+        Retrieve the datetime from given XPath as a string (YYYY-mm-ddTHH:MM:SSZ)
         """
         date_str = self._get_text_xpath(xpath)
         if date_str:
             datetime_obj = datetime.strptime(date_str, "%Y-%m-%d")
-            formatted_date_str = datetime_obj.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            formatted_date_str = datetime_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
             return formatted_date_str
         else:
             raise ValueError("No date found")
@@ -251,10 +250,10 @@ class MSRecordParser:
             "persistent_identifier": self.pid,
             "title": self._get_language_contents("//info:resourceName"),
             "description": self._get_language_contents("//info:description"),
-            "modified": self._get_date(
+            "modified": self._get_datetime(
                 "//info:metadataInfo/info:metadataLastDateUpdated/text()"
             ),
-            "issued": self._get_date(
+            "issued": self._get_datetime(
                 "//info:metadataInfo/info:metadataCreationDate/text()"
             ),
             "access_rights": self._map_access_rights(),

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -84,7 +84,7 @@ def _config_from_file(config_file):
             raise click.ClickException(
                 f'Value for "{configuration_value}" not found in configuration file'
             )
-        return config
+    return config
 
 
 @click.command()

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -107,7 +107,7 @@ def full_harvest(config_file):
     harvested_date = last_harvest_date(config["harvester_log_file"])
     logger_harvester.info("Started")
 
-    for record in metashare_api.fetch_records(from_timestamp=harvested_date):
+    for record in metashare_api.fetch_corpora(from_timestamp=harvested_date):
         metax_api.send_record(record)
 
     if harvested_date:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,8 +321,8 @@ def mock_metashare_get_single_record(
                 "en": "This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.",
                 "fi": "Tämä suomen kielen ajanilmauksia käsittävä aineisto on koottu kaunokirjallisten alkuperäisteosten, käännösten, murreaineistojen ja muiden tekstien pohjalta.",
             },
-            "modified": "2017-02-15T00:00:00.000000Z",
-            "issued": "2017-02-15T00:00:00.000000Z",
+            "modified": "2017-02-15T00:00:00Z",
+            "issued": "2017-02-15T00:00:00Z",
             "access_rights": {
                 "license": [
                     {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,7 +322,7 @@ def mock_metashare_get_single_record(
                 "fi": "Tämä suomen kielen ajanilmauksia käsittävä aineisto on koottu kaunokirjallisten alkuperäisteosten, käännösten, murreaineistojen ja muiden tekstien pohjalta.",
             },
             "modified": "2017-02-15T00:00:00Z",
-            "issued": "2017-02-15T00:00:00Z",
+            "created": "2017-02-15T00:00:00Z",
             "access_rights": {
                 "license": [
                     {

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -401,3 +401,22 @@ def test_full_harvest_no_new_records(
 
     assert shared_request_mocker.call_count == 3
     assert all(r.method == "GET" for r in shared_request_mocker.request_history)
+
+
+def test_cli_reporting_missing_configuration_values(create_test_config_file, run_cli):
+    """
+    Test that not providing all required configuration values in config file will
+    produce an informative error message and non-zero exit code.
+    """
+    create_test_config_file(
+        {
+            "metax_api_token": "qwerty",
+            "metax_base_url": "https://metax.fd-rework.csc.fi/",
+            "metax_catalog_id": "abc123",
+            # harvester_log_file not defined
+            "metax_api_log_file": "log.txt",
+        }
+    )
+    result = run_cli()
+    assert 'Value for "harvester_log_file" not found in configuration file'
+    assert result.exit_code != 0

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -320,7 +320,7 @@ def test_full_harvest_multiple_records(
 
     The requests we expect to see:
     GET to fetch the records from Metashare (for adding new records)
-    For each corpus record (5 in test data):
+    For each corpus record (4 in test data, one record is not a corpus):
         GET to get Metax PID (not found)
         POST to send the data to Metax
     GET to fetch the records from Metashare (again, for deleted records this time)
@@ -330,13 +330,13 @@ def test_full_harvest_multiple_records(
 
     assert result.exit_code == 0
 
-    assert shared_request_mocker.call_count == 13
+    assert shared_request_mocker.call_count == 11
     assert (
         sum(
             request.method == "POST"
             for request in shared_request_mocker.request_history
         )
-        == 5
+        == 4
     )
 
 
@@ -358,7 +358,7 @@ def test_full_harvest_without_log_file(shared_request_mocker, run_cli):
 
     The requests we expect to see:
     GET to fetch the records from Metashare (for adding new records)
-    For each corpus record (5 in test data):
+    For each corpus record (4 in test data):
         GET to get Metax PID (not found)
         POST to send the data to Metax
     GET to fetch the records from Metashare (again, for deleted records this time)
@@ -368,13 +368,13 @@ def test_full_harvest_without_log_file(shared_request_mocker, run_cli):
 
     assert result.exit_code == 0
 
-    assert shared_request_mocker.call_count == 13
+    assert shared_request_mocker.call_count == 11
     assert (
         sum(
             request.method == "POST"
             for request in shared_request_mocker.request_history
         )
-        == 5
+        == 4
     )
 
 

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -34,21 +34,21 @@ def test_pid(basic_metashare_record, dataset_pid):
     assert basic_metashare_record.pid == dataset_pid
 
 
-def test_get_modified_date(basic_metashare_record):
+def test_get_modified_datetime(basic_metashare_record):
     """Check that the modified date is returned in correct format."""
-    result = basic_metashare_record._get_date(
+    result = basic_metashare_record._get_datetime(
         "//info:metadataInfo/info:metadataLastDateUpdated/text()"
     )
-    expected_result = "2017-02-15T00:00:00.000000Z"
+    expected_result = "2017-02-15T00:00:00Z"
     assert result == expected_result
 
 
-def test_get_issued_date(basic_metashare_record):
-    """Check that the issued date is returned in correct format."""
-    result = basic_metashare_record._get_date(
+def test_get_created_datetime(basic_metashare_record):
+    """Check that the created date is returned in correct format."""
+    result = basic_metashare_record._get_datetime(
         "//info:metadataInfo/info:metadataCreationDate/text()"
     )
-    expected_result = "2017-02-15T00:00:00.000000Z"
+    expected_result = "2017-02-15T00:00:00Z"
     assert result == expected_result
 
 
@@ -68,8 +68,8 @@ def test_to_dict(basic_metashare_record):
             "en": "This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.",
             "fi": "T\u00e4m\u00e4 suomen kielen ajanilmauksia k\u00e4sitt\u00e4v\u00e4 aineisto on koottu kaunokirjallisten alkuper\u00e4isteosten, k\u00e4\u00e4nn\u00f6sten, murreaineistojen ja muiden tekstien pohjalta.",
         },
-        "modified": "2017-02-15T00:00:00.000000Z",
-        "issued": "2017-02-15T00:00:00.000000Z",
+        "modified": "2017-02-15T00:00:00Z",
+        "issued": "2017-02-15T00:00:00Z",
         "access_rights": {
             "license": [
                 {

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -69,7 +69,7 @@ def test_to_dict(basic_metashare_record):
             "fi": "T\u00e4m\u00e4 suomen kielen ajanilmauksia k\u00e4sitt\u00e4v\u00e4 aineisto on koottu kaunokirjallisten alkuper\u00e4isteosten, k\u00e4\u00e4nn\u00f6sten, murreaineistojen ja muiden tekstien pohjalta.",
         },
         "modified": "2017-02-15T00:00:00Z",
-        "issued": "2017-02-15T00:00:00Z",
+        "created": "2017-02-15T00:00:00Z",
         "access_rights": {
             "license": [
                 {


### PR DESCRIPTION
Metax specification has evolved, while our metadata output hasn't. This PR makes our metadata compatible with Metax v3 API again.

Also fixed some bugs introduced in the previous PRs that could not be tested against the real API due to the staging environment not being in good shape.