### PR TITLE
KP-7948 Logging output file setting in the configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.sw?
 config/*
 !config/template.yml
+logs/*
+!logs/.gitkeep

--- a/config/template.yml
+++ b/config/template.yml
@@ -1,2 +1,4 @@
 ---
 metax_api_token: filltokenhere
+
+harvester_log_file: logs/harvester.log

--- a/config/template.yml
+++ b/config/template.yml
@@ -2,3 +2,4 @@
 metax_api_token: filltokenhere
 
 harvester_log_file: logs/harvester.log
+metax_api_log_file: logs/metax_api_requests.log

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -74,6 +74,7 @@ def _config_from_file(config_file):
     expected_configuration_values = [
         "metax_api_token",
         "harvester_log_file",
+        "metax_api_log_file",
     ]
 
     for configuration_value in expected_configuration_values:
@@ -93,7 +94,10 @@ def full_harvest(config_file):
     """
     config = _config_from_file(config_file)
     metashare_api = PMH_API("https://kielipankki.fi/md_api/que")
-    metax_api = MetaxAPI(api_token=config["metax_api_token"])
+    metax_api = MetaxAPI(
+        api_token=config["metax_api_token"],
+        api_request_log_path=config["metax_api_log_file"],
+    )
 
     logger_harvester = setup_cli_logger(config["harvester_log_file"])
     harvested_date = last_harvest_date(config["harvester_log_file"])

--- a/metax_api.py
+++ b/metax_api.py
@@ -9,8 +9,8 @@ class MetaxAPI:
     An API client for interacting with the Metax V3 service.
     """
 
-    def __init__(self, api_token):
-        self.logger = self._setup_logger()
+    def __init__(self, api_token, api_request_log_path):
+        self.logger = self._setup_logger(api_request_log_path)
         self.base_url = "https://metax.fd-rework.csc.fi/v3"
         self.headers = {
             "Content-Type": "application/json",
@@ -19,13 +19,13 @@ class MetaxAPI:
         self.catalog_id = "urn:nbn:fi:att:data-catalog-kielipankki"
         self.timeout = 30
 
-    def _setup_logger(self):
+    def _setup_logger(self, api_request_log_path):
         """
         Set up and configure a logger for logging Metax API requests and responses.
         """
-        logger = logging.getLogger("metax_api_requests.log")
+        logger = logging.getLogger(api_request_log_path)
         logger.setLevel(logging.INFO)
-        file_handler = logging.FileHandler("metax_api_requests.log")
+        file_handler = logging.FileHandler(api_request_log_path)
         formatter = logging.Formatter(
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,19 @@ def shared_request_mocker():
 
 
 @pytest.fixture
-def metax_api():
-    return MetaxAPI(api_token="dummyapitoken")
+def default_metax_api_log_file_path(tmp_path):
+    """
+    Temporary log file for logging Metax API calls
+    """
+    return tmp_path / "metax.log"
+
+
+@pytest.fixture
+def metax_api(default_metax_api_log_file_path):
+    return MetaxAPI(
+        api_token="dummyapitoken",
+        api_request_log_path=str(default_metax_api_log_file_path),
+    )
 
 
 def _get_file_as_string(filename):

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -53,7 +53,9 @@ def create_test_config_file(tmp_path):
 
 
 @pytest.fixture
-def basic_configuration(create_test_config_file, default_test_log_file_path):
+def basic_configuration(
+    create_test_config_file, default_test_log_file_path, default_metax_api_log_file_path
+):
     """
     Create a basic well-formed configuration file and return its path.
     """
@@ -61,6 +63,7 @@ def basic_configuration(create_test_config_file, default_test_log_file_path):
         {
             "metax_api_token": "apitokentestvalue",
             "harvester_log_file": str(default_test_log_file_path),
+            "metax_api_log_file": str(default_metax_api_log_file_path),
         }
     )
 

--- a/tests/test_metax_api.py
+++ b/tests/test_metax_api.py
@@ -6,16 +6,29 @@ import requests_mock
 from metax_api import MetaxAPI
 
 
-def test_api_token_in_headers(mock_requests_post):
+def test_api_token_in_headers(mock_requests_post, default_metax_api_log_file_path):
     """
     Verify that the given API token is used when making requests.
     """
-    metax = MetaxAPI("token_test_value")
+    metax = MetaxAPI("token_test_value", str(default_metax_api_log_file_path))
     metax.create_record({"dummy": "data"})
     assert (
         mock_requests_post.request_history[0].headers["Authorization"]
         == "Token token_test_value"
     )
+
+
+@pytest.mark.usefixtures("mock_requests_post")
+def test_api_calls_logged(metax_api, default_metax_api_log_file_path):
+    """
+    Check that configuring the Metax API call logging works.
+
+    This is verified by ensuring that initially empty log file gets content when an API
+    call is made.
+    """
+    assert default_metax_api_log_file_path.stat().st_size == 0
+    metax_api.create_record({"dummy": "data"})
+    assert default_metax_api_log_file_path.stat().st_size != 0
 
 
 def test_record_id_pid_in_datacatalog(


### PR DESCRIPTION
This allows us to use the tool in environments where the "current directory" is not a place we want to write the logs in (e.g. cronjobs). The change applies both to the old `harvester.log` (the one from which we read the timestamps for previous harvests) and the Metax API request log (that we will likely want to disable altogether before going to production).

There was command-line option for the harvester log already, but it did not work (we can configure where we read it, but the place we write it was hard-coded) and a configuration file is more comfortable for cronjob etc use anyway.