### PR TITLE
KP-7949 Configurable Metax API URL and data catalog

### DIFF
--- a/config/template.yml
+++ b/config/template.yml
@@ -1,5 +1,7 @@
 ---
 metax_api_token: filltokenhere
+metax_base_url: https://metax.fd-rework.csc.fi/v3
+metax_catalog_id: urn:nbn:fi:att:data-catalog-kielipankki
 
 harvester_log_file: logs/harvester.log
 metax_api_log_file: logs/metax_api_requests.log

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -73,6 +73,8 @@ def _config_from_file(config_file):
 
     expected_configuration_values = [
         "metax_api_token",
+        "metax_base_url",
+        "metax_catalog_id",
         "harvester_log_file",
         "metax_api_log_file",
     ]
@@ -95,6 +97,8 @@ def full_harvest(config_file):
     config = _config_from_file(config_file)
     metashare_api = PMH_API("https://kielipankki.fi/md_api/que")
     metax_api = MetaxAPI(
+        base_url=config["metax_base_url"],
+        catalog_id=config["metax_catalog_id"],
         api_token=config["metax_api_token"],
         api_request_log_path=config["metax_api_log_file"],
     )

--- a/metax_api.py
+++ b/metax_api.py
@@ -9,14 +9,14 @@ class MetaxAPI:
     An API client for interacting with the Metax V3 service.
     """
 
-    def __init__(self, api_token, api_request_log_path):
+    def __init__(self, base_url, catalog_id, api_token, api_request_log_path):
         self.logger = self._setup_logger(api_request_log_path)
-        self.base_url = "https://metax.fd-rework.csc.fi/v3"
+        self.base_url = base_url
+        self.catalog_id = catalog_id
         self.headers = {
             "Content-Type": "application/json",
             "Authorization": f"Token {api_token}",
         }
-        self.catalog_id = "urn:nbn:fi:att:data-catalog-kielipankki"
         self.timeout = 30
 
     def _setup_logger(self, api_request_log_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,12 @@ def default_metax_api_log_file_path(tmp_path):
 
 
 @pytest.fixture
-def metax_api(default_metax_api_log_file_path):
+def metax_api(
+    default_metax_api_log_file_path, kielipankki_datacatalog_id, metax_base_url
+):
     return MetaxAPI(
+        base_url=metax_base_url,
+        catalog_id=kielipankki_datacatalog_id,
         api_token="dummyapitoken",
         api_request_log_path=str(default_metax_api_log_file_path),
     )

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -62,6 +62,8 @@ def basic_configuration(
     return create_test_config_file(
         {
             "metax_api_token": "apitokentestvalue",
+            "metax_base_url": "https://metax.fd-rework.csc.fi/v3",
+            "metax_catalog_id": "urn:nbn:fi:att:data-catalog-kielipankki",
             "harvester_log_file": str(default_test_log_file_path),
             "metax_api_log_file": str(default_metax_api_log_file_path),
         }

--- a/tests/test_metax_api.py
+++ b/tests/test_metax_api.py
@@ -6,25 +6,14 @@ import requests_mock
 from metax_api import MetaxAPI
 
 
-def test_api_token_in_headers(
-    mock_requests_post,
-    default_metax_api_log_file_path,
-    metax_base_url,
-    kielipankki_datacatalog_id,
-):
+def test_api_token_in_headers(mock_requests_post, metax_api):
     """
     Verify that the given API token is used when making requests.
     """
-    metax = MetaxAPI(
-        metax_base_url,
-        kielipankki_datacatalog_id,
-        "token_test_value",
-        str(default_metax_api_log_file_path),
-    )
-    metax.create_record({"dummy": "data"})
+    metax_api.create_record({"dummy": "data"})
     assert (
         mock_requests_post.request_history[0].headers["Authorization"]
-        == "Token token_test_value"
+        == "Token dummyapitoken"
     )
 
 

--- a/tests/test_metax_api.py
+++ b/tests/test_metax_api.py
@@ -6,11 +6,21 @@ import requests_mock
 from metax_api import MetaxAPI
 
 
-def test_api_token_in_headers(mock_requests_post, default_metax_api_log_file_path):
+def test_api_token_in_headers(
+    mock_requests_post,
+    default_metax_api_log_file_path,
+    metax_base_url,
+    kielipankki_datacatalog_id,
+):
     """
     Verify that the given API token is used when making requests.
     """
-    metax = MetaxAPI("token_test_value", str(default_metax_api_log_file_path))
+    metax = MetaxAPI(
+        metax_base_url,
+        kielipankki_datacatalog_id,
+        "token_test_value",
+        str(default_metax_api_log_file_path),
+    )
     metax.create_record({"dummy": "data"})
     assert (
         mock_requests_post.request_history[0].headers["Authorization"]


### PR DESCRIPTION
Now we can configure the catalog ID and Metax API url, allowing us to easily change to production server when one is up, as well as possibly still do testing against a development server if needed.

~NB: This is done on top of https://github.com/CSCfi/Kielipankki-Metax-bridge/pull/11 because a more robust way of validating configuration file contents was introduced there and I wanted to use it here. That PR should be merged first, otherwise this diff will look bigger than it is. Otherwise this PR is all done.~ done