### PR TITLE
KP-7466 Provide real language info to Metax

### DIFF
--- a/harvester/language_validator.py
+++ b/harvester/language_validator.py
@@ -1,0 +1,34 @@
+"""
+Helpers for verifying that a provided language URI is accepted by Metax.
+"""
+
+import functools
+
+import requests
+
+
+@functools.lru_cache
+def _allowed_language_uris(language_vocabulary_endpoint):
+    """
+    Return a list of allowed language URIs from the given endpoint.
+
+    The HTTP request is made only once, consecutive calls get cached data.
+    """
+    metax_languages_response = requests.get(language_vocabulary_endpoint)
+    metax_languages_response.raise_for_status()
+
+    return {
+        hit["_source"]["uri"] for hit in metax_languages_response.json()["hits"]["hits"]
+    }
+
+
+def language_in_vocabulary(
+    language_uri,
+    language_vocabulary_endpoint="https://metax.fairdata.fi/es/reference_data/language/_search?size=10000",
+):
+    """
+    Check whether given language URI is listed in the vocabulary.
+
+    The default vocabulary is that of production Metax.
+    """
+    return language_uri in _allowed_language_uris(language_vocabulary_endpoint)

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -14,7 +14,7 @@ class MSRecordParser:
         """
         self.xml = xml
 
-    def _get_language_contents(self, xpath):
+    def _get_element_text_in_preferred_language(self, xpath):
         """
         Retrieve the content from XML tree and XPath expression for different language versions.
 
@@ -297,8 +297,12 @@ class MSRecordParser:
                 }
             ],
             "persistent_identifier": self.pid,
-            "title": self._get_language_contents("//info:resourceName"),
-            "description": self._get_language_contents("//info:description"),
+            "title": self._get_element_text_in_preferred_language(
+                "//info:resourceName"
+            ),
+            "description": self._get_element_text_in_preferred_language(
+                "//info:description"
+            ),
             "modified": self._get_datetime(
                 "//info:metadataInfo/info:metadataLastDateUpdated/text()"
             ),

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-import iso639
 from urllib.parse import urlparse
 
 from lxml import etree
+import iso639
 
 from harvester import language_validator
 

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 
 from lxml import etree
 
+from harvester import language_validator
+
 
 class MSRecordParser:
     def __init__(self, xml):
@@ -263,14 +265,17 @@ class MSRecordParser:
                 language = iso639.Lang(language_code.lower())
 
                 if language.pt3:
-                    iso639_urls.add(f"http://lexvo.org/id/iso639-3/{language.pt3}")
+                    language_uri = f"http://lexvo.org/id/iso639-3/{language.pt3}"
                 elif language.pt5:
-                    iso639_urls.add(f"http://lexvo.org/id/iso639-5/{language.pt5}")
+                    language_uri = f"http://lexvo.org/id/iso639-5/{language.pt5}"
                 else:
                     raise ValueError(
                         "Could not determine three-letter language code for %s"
                         % language_code,
                     )
+
+                if language_validator.language_in_vocabulary(language_uri):
+                    iso639_urls.add(language_uri)
 
             except iso639.exceptions.InvalidLanguageValue:
                 if language_code in ["hbk", "hbp"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click
+iso639-lang
 sickle
 lxml
 PyYAML

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,3 +384,34 @@ def license_with_custom_url_record():
     """A record containing lisence url in documentation elements."""
     with open("tests/test_data/res_with_license_url.xml") as xmlfile:
         return MSRecordParser(etree.fromstring(xmlfile.read()))
+
+
+@pytest.fixture
+def language_vocabulary_endpoint_url():
+    """
+    URL for "fetching" the language vocabulary in tests.
+    """
+    return "https://metax.fairdata.fi/es/reference_data/language/_search?size=10000"
+
+
+@pytest.fixture(autouse=True)
+def mock_metax_language_vocabulary_endpoint(
+    language_vocabulary_endpoint_url, shared_request_mocker
+):
+    """
+    Make GET requests to the "Metax language vocabulary endpoint" return a small mocked
+    response.
+
+    This response will only list five languages/language families:
+     - http://lexvo.org/id/iso639-3/kaf
+     - http://lexvo.org/id/iso639-5/smi
+     - http://lexvo.org/id/iso639-3/eng
+     - http://lexvo.org/id/iso639-3/fin
+     - http://lexvo.org/id/iso639-3/swe
+
+    The response dicts are also somewhat trimmed down, because we don't need the full
+    data with all translations.
+    """
+    with open("tests/test_data/metax_language_vocabulary.json", "r") as response_json:
+        data = json.loads(response_json.read())
+    shared_request_mocker.get(language_vocabulary_endpoint_url, json=data)

--- a/tests/harvester/test_language_validator.py
+++ b/tests/harvester/test_language_validator.py
@@ -1,0 +1,24 @@
+import json
+import pytest
+
+from harvester import language_validator
+
+
+@pytest.mark.usefixtures("mock_metax_language_vocabulary_endpoint")
+def test_language_in_vocabulary(language_vocabulary_endpoint_url):
+    """
+    Test that languages and language families from the test response are really reported
+    as valid, and languages not present in the test response are not valid.
+    """
+    assert language_validator.language_in_vocabulary(
+        "http://lexvo.org/id/iso639-3/fin",
+        language_vocabulary_endpoint=language_vocabulary_endpoint_url,
+    )
+    assert language_validator.language_in_vocabulary(
+        "http://lexvo.org/id/iso639-5/smi",
+        language_vocabulary_endpoint=language_vocabulary_endpoint_url,
+    )
+    assert not language_validator.language_in_vocabulary(
+        "http://lexvo.org/id/iso639-3/åäö",
+        language_vocabulary_endpoint=language_vocabulary_endpoint_url,
+    )

--- a/tests/test_data/kielipankki_record_sample_multiple_languages.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_languages.xml
@@ -1,0 +1,193 @@
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+<responseDate>2023-08-10T06:22:09Z</responseDate>
+<request verb="GetRecord" identifier="oai:kielipankki.fi:sh0721e0" metadataPrefix="info">https://kielipankki.fi/md_api/que</request>
+<GetRecord>
+  <record>
+    <header>
+      <identifier>oai:kielipankki.fi:sh0721e0</identifier>
+      <datestamp>2023-03-22T05:03:42Z</datestamp>
+    </header>
+    <metadata>
+      <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+      <identificationInfo>
+        <resourceName lang="en">
+          The Finnish Broadcasting Company Corpus of Subtitles
+        </resourceName>
+        <description lang="fi">
+          Jukka Mäkisalon ja Sonja Tirkkonen-Condit v. 2005 laatima käännetyn tekstityksen digitaalinen tutkimusaineisto. Yle-ruututeksikorpus sisältää kaikki Ylen lähettämät digitaaliset tv-tekstitykset v. 1992-2004.
+        </description>
+        <description lang="en">
+          Digital research material of translated subtitles compiled by Jukka Mäkisalo and Sonja Tirkkonen-Condit, 2005. The corpus contains all the digital TV subtitles of the Finnish Broadcasting Company from 1992 to 2004.
+        </description>
+        <resourceShortName lang="fi">YLE-korpus</resourceShortName>
+        <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+        <identifier>http://urn.fi/urn:nbn:fi:lb-20140730134</identifier>
+      </identificationInfo>
+      <distributionInfo>
+        <availability>underNegotiation</availability>
+        <licenceInfo>
+          <licence>underNegotiation</licence>
+          <distributionAccessMedium>CD-ROM</distributionAccessMedium>
+          <licensor>
+            <personInfo>
+              <surname lang="en">Mäkisalo</surname>
+              <givenName lang="en">Jukka</givenName>
+              <sex>male</sex>
+              <communicationInfo>
+                <email>jukka.makisalo@uef.fi</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="fi">Itä-Suomen yliopisto</organizationName>
+                <organizationName lang="en">University of Eastern Finland</organizationName>
+                <organizationShortName lang="en">UEF</organizationShortName>
+                <communicationInfo>
+                  <email>kirjaamo@uef.fi</email>
+                  <url>http://www.uef.fi/uef/english</url>
+                  <url>https://ror.org/00cyydd11</url>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </personInfo>
+          </licensor>
+          <distributionRightsHolder>
+            <personInfo>
+              <surname lang="en">Mäkisalo</surname>
+              <givenName lang="en">Jukka</givenName>
+              <sex>male</sex>
+              <communicationInfo>
+                <email>jukka.makisalo@uef.fi</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="fi">Itä-Suomen yliopisto</organizationName>
+                <organizationName lang="en">University of Eastern Finland</organizationName>
+                <organizationShortName lang="en">UEF</organizationShortName>
+                <communicationInfo>
+                  <email>kirjaamo@uef.fi</email>
+                  <url>http://www.uef.fi/uef/english</url>
+                  <url>https://ror.org/00cyydd11</url>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </personInfo>
+          </distributionRightsHolder>
+          <userNature>academic</userNature>
+        </licenceInfo>
+        <iprHolder>
+          <personInfo>
+            <surname lang="en">Mäkisalo</surname>
+            <givenName lang="en">Jukka</givenName>
+            <sex>male</sex>
+            <communicationInfo>
+              <email>jukka.makisalo@uef.fi</email>
+            </communicationInfo>
+            <affiliation>
+              <organizationName lang="fi">Itä-Suomen yliopisto</organizationName>
+              <organizationName lang="en">University of Eastern Finland</organizationName>
+              <organizationShortName lang="en">UEF</organizationShortName>
+              <communicationInfo>
+                <email>kirjaamo@uef.fi</email>
+                <url>http://www.uef.fi/uef/english</url>
+                <url>https://ror.org/00cyydd11</url>
+                <country>Finland</country>
+              </communicationInfo>
+            </affiliation>
+          </personInfo>
+        </iprHolder>
+      </distributionInfo>
+      <contactPerson>
+        <surname lang="en">Mäkisalo</surname>
+        <givenName lang="en">Jukka</givenName>
+        <sex>male</sex>
+        <communicationInfo>
+          <email>jukka.makisalo@uef.fi</email>
+        </communicationInfo>
+        <affiliation>
+          <organizationName lang="fi">Itä-Suomen yliopisto</organizationName>
+          <organizationName lang="en">University of Eastern Finland</organizationName>
+          <organizationShortName lang="en">UEF</organizationShortName>
+          <communicationInfo>
+            <email>kirjaamo@uef.fi</email>
+            <url>http://www.uef.fi/uef/english</url>
+            <url>https://ror.org/00cyydd11</url>
+            <country>Finland</country>
+          </communicationInfo>
+        </affiliation>
+      </contactPerson>
+      <metadataInfo>
+        <metadataCreationDate>2012-08-02</metadataCreationDate>
+        <metadataCreator>
+          <surname lang="en">Bartis</surname>
+          <givenName lang="en">Imre</givenName>
+          <sex>male</sex>
+          <communicationInfo>
+            <email>imre.bartis@helsinki.fi</email>
+            <url>http://orcid.org/0000-0002-9455-8771</url>
+            <city>Helsinki</city>
+            <country>Finland</country>
+          </communicationInfo>
+          <position>Project Coordinator</position>
+          <affiliation>
+            <organizationName lang="en">FIN-CLARIN</organizationName>
+            <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+            <departmentName lang="en">University of Helsinki</departmentName>
+            <communicationInfo>
+              <email>finclarin@helsinki.fi</email>
+              <url>http://www.helsinki.fi/fin-clarin</url>
+              <address>PO Box 24 (Unioninkatu 40)</address>
+              <zipCode>00014</zipCode>
+              <city>University of Helsinki</city>
+              <country>Finland</country>
+            </communicationInfo>
+          </affiliation>
+        </metadataCreator>
+        <metadataLanguageName>Finnish</metadataLanguageName>
+        <metadataLanguageName>English</metadataLanguageName>
+        <metadataLanguageId>Fi</metadataLanguageId>
+        <metadataLanguageId>en</metadataLanguageId>
+        <metadataLastDateUpdated>2014-04-24</metadataLastDateUpdated>
+      </metadataInfo>
+
+      <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+        <corpusInfo>
+          <resourceType>corpus</resourceType>
+          <corpusMediaType>
+            <corpusTextInfo>
+              <mediaType>text</mediaType>
+              <lingualityInfo>
+                <lingualityType>multilingual</lingualityType>
+                <multilingualityType>multilingualSingleText</multilingualityType>
+              </lingualityInfo>
+              <languageInfo>
+                <languageId>Fi</languageId>
+                <languageName>Finnish</languageName>
+              </languageInfo>
+              <languageInfo>
+                <languageId>En</languageId>
+                <languageName>English</languageName>
+              </languageInfo>
+              <languageInfo>
+                <languageId>Sv</languageId>
+                <languageName>Swedish</languageName>
+              </languageInfo>
+              <languageInfo>
+                <languageId>smi</languageId>
+                <languageName>Sami languages</languageName>
+              </languageInfo>
+              <modalityInfo>
+                <modalityType>spokenLanguage</modalityType>
+              </modalityInfo>
+              <sizeInfo>
+                <size>100000000</size>
+                <sizeUnit>words</sizeUnit>
+              </sizeInfo>
+            </corpusTextInfo>
+          </corpusMediaType>
+        </corpusInfo>
+      </resourceComponentType>
+    </info:resourceInfo>
+  </metadata>
+</record>
+</GetRecord>
+</OAI-PMH>

--- a/tests/test_data/kielipankki_record_sample_multiple_languages.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_languages.xml
@@ -175,6 +175,10 @@
                 <languageId>smi</languageId>
                 <languageName>Sami languages</languageName>
               </languageInfo>
+              <languageInfo>
+                <languageId>abc</languageId>
+                <languageName>Unsupported language</languageName>
+              </languageInfo>
               <modalityInfo>
                 <modalityType>spokenLanguage</modalityType>
               </modalityInfo>

--- a/tests/test_data/metax_language_vocabulary.json
+++ b/tests/test_data/metax_language_vocabulary.json
@@ -1,0 +1,150 @@
+{
+  "took": 68,
+  "timed_out": false,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 5,
+      "relation": "eq"
+    },
+    "max_score": 2.300493,
+    "hits": [
+      {
+        "_index": "reference_data",
+        "_type": "_doc",
+        "_id": "language_kaf",
+        "_score": 2.300493,
+        "_source": {
+          "id": "language_kaf",
+          "code": "kaf",
+          "type": "language",
+          "uri": "http://lexvo.org/id/iso639-3/kaf",
+          "wkt": "",
+          "input_file_format": "",
+          "output_format_version": "",
+          "label": {
+            "en": "Katso",
+            "und": "Katso"
+          },
+          "parent_ids": [],
+          "child_ids": [],
+          "has_children": false,
+          "same_as": [],
+          "internal_code": "",
+          "scheme": "http://lexvo.org/id/"
+        }
+      },
+      {
+        "_index": "reference_data",
+        "_type": "_doc",
+        "_id": "language_smi",
+        "_score": 2.2677848,
+        "_source": {
+          "id": "language_smi",
+          "code": "smi",
+          "type": "language",
+          "uri": "http://lexvo.org/id/iso639-5/smi",
+          "wkt": "",
+          "input_file_format": "",
+          "output_format_version": "",
+          "label": {
+            "cs": "sámské jazyky",
+            "fi": "saamelaiskieli",
+            "ee": "Samigbe",
+            "id": "Bahasa Sami",
+            "und": "saamelaiskieli"
+          },
+          "parent_ids": [],
+          "child_ids": [],
+          "has_children": false,
+          "same_as": [],
+          "internal_code": "",
+          "scheme": "http://lexvo.org/id/"
+        }
+      },
+            {
+        "_index": "reference_data",
+        "_type": "_doc",
+        "_id": "language_eng",
+        "_score": 2.300493,
+        "_source": {
+          "id": "language_eng",
+          "code": "eng",
+          "type": "language",
+          "uri": "http://lexvo.org/id/iso639-3/eng",
+          "wkt": "",
+          "input_file_format": "",
+          "output_format_version": "",
+          "label": {
+            "yue": "英文",
+            "bar": "Englische Sproch",
+            "fi": "englanti",
+            "zsm": "Inggeris",
+            "os": "англисаг",
+            "und": "englanti"
+          },
+          "parent_ids": [],
+          "child_ids": [],
+          "has_children": false,
+          "same_as": [],
+          "internal_code": "",
+          "scheme": "http://lexvo.org/id/"
+        }
+      },
+      {
+        "_index": "reference_data",
+        "_type": "_doc",
+        "_id": "language_fin",
+        "_score": 2.300493,
+        "_source": {
+          "id": "language_fin",
+          "code": "fin",
+          "type": "language",
+          "uri": "http://lexvo.org/id/iso639-3/fin",
+          "wkt": "",
+          "input_file_format": "",
+          "output_format_version": "",
+          "label": {
+            "he": "פינית",
+            "fi": "suomi",
+            "fr": "finnois",
+            "fil": "Finnish",
+            "udm": "Финн кыл",
+            "und": "suomi"
+          },
+          "parent_ids": [],
+          "child_ids": [],
+          "has_children": false,
+          "same_as": [],
+          "internal_code": "",
+          "scheme": "http://lexvo.org/id/"
+        }
+      },
+      {
+        "_index": "reference_data",
+        "_type": "_doc",
+        "_id": "language_swe",
+        "_score": 2.2677848,
+        "_source": {
+          "id": "language_swe",
+          "code": "swe",
+          "type": "language",
+          "uri": "http://lexvo.org/id/iso639-3/swe",
+          "wkt": "",
+          "input_file_format": "",
+          "output_format_version": "",
+          "label": {
+            "fi": "ruotsi",
+            "nah": "Sueciatlahtōlli",
+            "be": "шведская"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -219,3 +219,33 @@ def missing_pid_record():
 def test_check_pid_exists(missing_pid_record):
     """Check that a missing PID is handled."""
     assert not missing_pid_record.check_pid_exists()
+
+
+def test_get_resource_languages(basic_metashare_record):
+    """
+    Verify that a single language from a record is returned in Metax-approved format.
+
+    Metax espects a list of dicts, each dict describing one language. The only
+    information required for each language is a lexvo url.
+    """
+    assert basic_metashare_record._get_resource_languages() == [
+        {"url": "http://lexvo.org/id/iso639-3/fin"}
+    ]
+
+
+def test_get_resource_languages_with_multiple_languages():
+    """
+    Check that multiple languages for one resource are reported properly. Also includes
+    an ISO 639-5 language.
+    """
+    record = MSRecordParser(
+        _get_file_as_lxml(
+            "tests/test_data/kielipankki_record_sample_multiple_languages.xml"
+        )
+    )
+    languages = record._get_resource_languages()
+    assert len(languages) == 4
+
+    language_urls = [language["url"] for language in languages]
+    assert "http://lexvo.org/id/iso639-5/smi" in language_urls
+    assert "http://lexvo.org/id/iso639-3/swe" in language_urls

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -11,7 +11,9 @@ def _get_file_as_lxml(filename):
 
 def test_get_title(basic_metashare_record):
     """Testing that different language versions of "title" are mapped."""
-    result = basic_metashare_record._get_language_contents("//info:resourceName")
+    result = basic_metashare_record._get_element_text_in_preferred_language(
+        "//info:resourceName"
+    )
     expected_result = {
         "en": "Silva Kiuru's Time Expressions Corpus",
         "fi": "Silva Kiurun ajanilmausaineisto",
@@ -21,7 +23,9 @@ def test_get_title(basic_metashare_record):
 
 def test_get_description(basic_metashare_record):
     """Testing that different language versions of "description" are mapped."""
-    result = basic_metashare_record._get_language_contents("//info:description")
+    result = basic_metashare_record._get_element_text_in_preferred_language(
+        "//info:description"
+    )
     expected_result = {
         "en": "This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.",
         "fi": "T\u00e4m\u00e4 suomen kielen ajanilmauksia k\u00e4sitt\u00e4v\u00e4 aineisto on koottu kaunokirjallisten alkuper\u00e4isteosten, k\u00e4\u00e4nn\u00f6sten, murreaineistojen ja muiden tekstien pohjalta.",


### PR DESCRIPTION
Languages are now really parsed from Metashare metadata, converted to Lexvo URIs and provided to Metax.

The source data is not 100% neat, so there's special handling for the different flavours of Hungarian. Officially Metax says that they only support ISO 639-3, but in practice they also accept some (but not all) 639-5 codes, so those are used if set 3 code is not available for a language. Because all codes from set 5 are not accepted, the URIs are checked against the list of allowed values from Metax and incompatible language families are silently dropped. Reporting them is to be done in [KP-7441](https://jira.eduuni.fi/browse/KP-7441).

The pre-existing `_get_language_contents` method was renamed in order to prevent it from being confused with the new language parsing method.