### PR TITLE
KP-7466 Set field of science to humanities>languages

### DIFF
--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -293,12 +293,11 @@ class MSRecordParser:
         Converts text and dictionaries to Metax compliant dictionary.
         """
         return {
-            # field_of_science is dummy data until they are implemented later on
             "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",
             "language": self._get_resource_languages(),
             "field_of_science": [
                 {
-                    "url": "http://www.yso.fi/onto/okm-tieteenala/ta112",
+                    "url": "http://www.yso.fi/onto/okm-tieteenala/ta6121",
                 }
             ],
             "persistent_identifier": self.pid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,7 +310,7 @@ def mock_metashare_get_single_record(
             "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",
             "language": [{"url": "http://lexvo.org/id/iso639-3/fin"}],
             "field_of_science": [
-                {"url": "http://www.yso.fi/onto/okm-tieteenala/ta112"}
+                {"url": "http://www.yso.fi/onto/okm-tieteenala/ta6121"}
             ],
             "persistent_identifier": "urn.fi/urn:nbn:fi:lb-2016101210",
             "title": {

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -62,7 +62,7 @@ def test_to_dict(basic_metashare_record):
     expected_result = {
         "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",
         "language": [{"url": "http://lexvo.org/id/iso639-3/fin"}],
-        "field_of_science": [{"url": "http://www.yso.fi/onto/okm-tieteenala/ta112"}],
+        "field_of_science": [{"url": "http://www.yso.fi/onto/okm-tieteenala/ta6121"}],
         "persistent_identifier": "urn.fi/urn:nbn:fi:lb-2016101210",
         "title": {
             "en": "Silva Kiuru's Time Expressions Corpus",


### PR DESCRIPTION
Metashare does not specify field of science, so it was specified that all our data should be language data. The code has now been updated to [humanities>languages](https://finto.fi/okm-tieteenala/fi/page/ta6121).