### PR TITLE
KP-7427 Add actors (person only)

### DIFF
--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -36,8 +36,10 @@ class Actor:
         """
         if "givenName" in self.data:
             return f"{self.data['givenName']} {self.data['surname']}"
-        else:
+        elif "surname" in self.data:
             return f"{self.data['surname']}"
+        else:
+            return None
 
     @property
     def email(self):
@@ -48,7 +50,8 @@ class Actor:
         return communicationInfo.get("email", None)
 
     def to_metax_dict(self):
-        return {
-            "roles": list(self.roles),
-            "person": {"name": self.name, "email": self.email},
-        }
+        if self.name:
+            person_dict = {"name": self.name, "email": self.email}
+        else:
+            person_dict = None
+        return {"roles": list(self.roles), "person": person_dict}

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -49,9 +49,35 @@ class Actor:
         communicationInfo = self.data.get("communicationInfo", {})
         return communicationInfo.get("email", None)
 
+    def add_roles(self, roles):
+        """
+        Add given roles for this actor.
+        """
+        self.roles.update(roles)
+
     def to_metax_dict(self):
+        """
+        Return the actor as a Metax-compatible dict
+
+        The list of roles is sorted to make sure that the representation for a same
+        actor always stays the same. In addition to just being neat, this also improves
+        testaibility. Performance hit should be minimal, as the lists are tiny (4 items
+        at most).
+        """
         if self.name:
             person_dict = {"name": self.name, "email": self.email}
         else:
             person_dict = None
-        return {"roles": list(self.roles), "person": person_dict}
+        return {"roles": sorted(list(self.roles)), "person": person_dict}
+
+    def __eq__(self, other):
+        """
+        Check if two objects represent the same person.
+
+        The actors are deemed equal if their names and emails match. This allows merging
+        the entries of same person having multiple roles.
+        """
+        if not isinstance(other, Actor):
+            return False
+
+        return self.name == other.name and self.email == other.email

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -1,0 +1,54 @@
+import re
+
+
+class Actor:
+    def __init__(self, element, roles):
+        """
+        Create a new actor.
+
+        Thea actor data is parsed from the input lxml Element into a dict for easier
+        use. The root element (e.g. "contactPerson") is omitted, because that
+        information is already included in `roles`.
+        """
+        self.data = self._etree_to_dict(element)
+        if len(self.data) == 1:
+            self.data = list(self.data.values())[0]
+
+        self.roles = set(roles)
+
+    def _etree_to_dict(self, element):
+        result = {}
+        key = re.sub("{.*}", "", element.tag)
+        if len(element) == 0:
+            result[key] = element.text
+        else:
+            subresult = {}
+            for child in element:
+                subresult.update(self._etree_to_dict(child))
+            result[key] = subresult
+
+        return result
+
+    @property
+    def name(self):
+        """
+        Return
+        """
+        if "givenName" in self.data:
+            return f"{self.data['givenName']} {self.data['surname']}"
+        else:
+            return f"{self.data['surname']}"
+
+    @property
+    def email(self):
+        """
+        Email address of the person. None if not available.
+        """
+        communicationInfo = self.data.get("communicationInfo", {})
+        return communicationInfo.get("email", None)
+
+    def to_metax_dict(self):
+        return {
+            "roles": list(self.roles),
+            "person": {"name": self.name, "email": self.email},
+        }

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -64,11 +64,21 @@ class Actor:
         testaibility. Performance hit should be minimal, as the lists are tiny (4 items
         at most).
         """
+        return {"roles": sorted(list(self.roles)), "person": self._person_dict}
+
+    @property
+    def _person_dict(self):
         if self.name:
-            person_dict = {"name": self.name, "email": self.email}
+            return {"name": self.name, "email": self.email}
         else:
-            person_dict = None
-        return {"roles": sorted(list(self.roles)), "person": person_dict}
+            return None
+
+    @property
+    def has_person_data(self):
+        """
+        Return True if the actor has information about an individual person.
+        """
+        return self._person_dict is not None
 
     def __eq__(self, other):
         """

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -312,10 +312,16 @@ class MSRecordParser:
                 curator_elements = [curator_elements]
 
             for curator_element in curator_elements:
-                curator_actor = Actor(curator_element, roles=[role])
-                actors.append(curator_actor.to_metax_dict())
+                actors.append(Actor(curator_element, roles=[role]))
 
-        return actors
+        merged_actors = []
+        for actor in actors:
+            if actor not in merged_actors:
+                merged_actors.append(actor)
+            else:
+                merged_actors[merged_actors.index(actor)].add_roles(actor.roles)
+
+        return [actor.to_metax_dict() for actor in merged_actors]
 
     def to_dict(self):
         """

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -297,6 +297,7 @@ class MSRecordParser:
 
         actor_role_element_xpaths = {
             "creator": "//info:metadataInfo/info:metadataCreator",
+            "publisher": "//info:distributionInfo/info:licenceInfo/info:distributionRightsHolder",
             "curator": "//info:resourceInfo/info:contactPerson",
         }
 

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -296,6 +296,7 @@ class MSRecordParser:
         actors = []
 
         actor_role_element_xpaths = {
+            "creator": "//info:metadataInfo/info:metadataCreator",
             "curator": "//info:resourceInfo/info:contactPerson",
         }
 
@@ -303,7 +304,7 @@ class MSRecordParser:
             curator_elements = self.xml.xpath(
                 xpath,
                 namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"},
-            )[0]
+            )
 
             if not isinstance(curator_elements, list):
                 curator_elements = [curator_elements]

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -313,6 +313,8 @@ class MSRecordParser:
 
             for curator_element in curator_elements:
                 new_actor = Actor(curator_element, roles=[role])
+                if not new_actor.has_person_data:
+                    continue
                 if new_actor in actors:
                     actors[actors.index(new_actor)].add_roles(new_actor.roles)
                 else:

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -295,17 +295,22 @@ class MSRecordParser:
         """
         actors = []
 
-        curator_elements = self.xml.xpath(
-            "//info:resourceInfo/info:contactPerson",
-            namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"},
-        )[0]
+        actor_role_element_xpaths = {
+            "curator": "//info:resourceInfo/info:contactPerson",
+        }
 
-        if not isinstance(curator_elements, list):
-            curator_elements = [curator_elements]
+        for role, xpath in actor_role_element_xpaths.items():
+            curator_elements = self.xml.xpath(
+                xpath,
+                namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"},
+            )[0]
 
-        for curator_element in curator_elements:
-            curator_actor = Actor(curator_element, roles=["curator"])
-            actors.append(curator_actor.to_metax_dict())
+            if not isinstance(curator_elements, list):
+                curator_elements = [curator_elements]
+
+            for curator_element in curator_elements:
+                curator_actor = Actor(curator_element, roles=[role])
+                actors.append(curator_actor.to_metax_dict())
 
         return actors
 

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -299,6 +299,7 @@ class MSRecordParser:
             "creator": "//info:metadataInfo/info:metadataCreator",
             "publisher": "//info:distributionInfo/info:licenceInfo/info:distributionRightsHolder",
             "curator": "//info:resourceInfo/info:contactPerson",
+            "rights_holder": "//info:distributionInfo/info:iprHolder",
         }
 
         for role, xpath in actor_role_element_xpaths.items():

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -312,16 +312,13 @@ class MSRecordParser:
                 curator_elements = [curator_elements]
 
             for curator_element in curator_elements:
-                actors.append(Actor(curator_element, roles=[role]))
+                new_actor = Actor(curator_element, roles=[role])
+                if new_actor in actors:
+                    actors[actors.index(new_actor)].add_roles(new_actor.roles)
+                else:
+                    actors.append(new_actor)
 
-        merged_actors = []
-        for actor in actors:
-            if actor not in merged_actors:
-                merged_actors.append(actor)
-            else:
-                merged_actors[merged_actors.index(actor)].add_roles(actor.roles)
-
-        return [actor.to_metax_dict() for actor in merged_actors]
+        return [actor.to_metax_dict() for actor in actors]
 
     def to_dict(self):
         """

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from lxml import etree
 import iso639
 
+from harvester.actor import Actor
 from harvester import language_validator
 
 
@@ -288,6 +289,26 @@ class MSRecordParser:
 
         return [{"url": url} for url in iso639_urls]
 
+    def _get_actors(self):
+        """
+        Return the actors for this resource.
+        """
+        actors = []
+
+        curator_elements = self.xml.xpath(
+            "//info:resourceInfo/info:contactPerson",
+            namespaces={"info": "http://www.ilsp.gr/META-XMLSchema"},
+        )[0]
+
+        if not isinstance(curator_elements, list):
+            curator_elements = [curator_elements]
+
+        for curator_element in curator_elements:
+            curator_actor = Actor(curator_element, roles=["curator"])
+            actors.append(curator_actor.to_metax_dict())
+
+        return actors
+
     def to_dict(self):
         """
         Converts text and dictionaries to Metax compliant dictionary.
@@ -314,4 +335,5 @@ class MSRecordParser:
                 "//info:metadataInfo/info:metadataCreationDate/text()"
             ),
             "access_rights": self._map_access_rights(),
+            "actors": self._get_actors(),
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,7 +342,6 @@ def mock_metashare_get_single_record(
                     },
                     "roles": ["creator"],
                 },
-                {"person": None, "roles": ["publisher", "rights_holder"]},
                 {
                     "roles": ["curator"],
                     "person": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -334,6 +334,15 @@ def mock_metashare_get_single_record(
                     "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
                 },
             },
+            "actors": [
+                {
+                    "roles": ["curator"],
+                    "person": {
+                        "name": "Mari Siiroinen",
+                        "email": "mari.siiroinen@helsinki.fi",
+                    },
+                }
+            ],
         }
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,6 +342,7 @@ def mock_metashare_get_single_record(
                     },
                     "roles": ["creator"],
                 },
+                {"person": None, "roles": ["publisher"]},
                 {
                     "roles": ["curator"],
                     "person": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,6 +350,7 @@ def mock_metashare_get_single_record(
                         "email": "mari.siiroinen@helsinki.fi",
                     },
                 },
+                {"person": None, "roles": ["rights_holder"]},
             ],
         }
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,12 +336,19 @@ def mock_metashare_get_single_record(
             },
             "actors": [
                 {
+                    "person": {
+                        "email": "imre.bartis@helsinki.fi",
+                        "name": "Imre Bartis",
+                    },
+                    "roles": ["creator"],
+                },
+                {
                     "roles": ["curator"],
                     "person": {
                         "name": "Mari Siiroinen",
                         "email": "mari.siiroinen@helsinki.fi",
                     },
-                }
+                },
             ],
         }
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,7 +342,7 @@ def mock_metashare_get_single_record(
                     },
                     "roles": ["creator"],
                 },
-                {"person": None, "roles": ["publisher"]},
+                {"person": None, "roles": ["publisher", "rights_holder"]},
                 {
                     "roles": ["curator"],
                     "person": {
@@ -350,7 +350,6 @@ def mock_metashare_get_single_record(
                         "email": "mari.siiroinen@helsinki.fi",
                     },
                 },
-                {"person": None, "roles": ["rights_holder"]},
             ],
         }
     ]

--- a/tests/test_data/kielipankki_record_sample_multiple_actors.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_actors.xml
@@ -1,0 +1,214 @@
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2023-08-10T06:22:09Z</responseDate>
+  <request verb="GetRecord" identifier="oai:kielipankki.fi:sh41ac60" metadataPrefix="info">https://kielipankki.fi/md_api/que</request>
+  <GetRecord>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/">
+      <header>
+        <identifier>oai:kielipankki.fi:sh41ac60</identifier>
+        <datestamp>2022-11-17T04:02:11Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="fi">Suomenkielinen OpenSubtitles 2017, Kielipankin Korp-versio</resourceName>
+            <resourceName lang="en">Finnish OpenSubtitles 2017, Kielipankki Korp Version</resourceName>
+            <description lang="fi">OpenSubtitles kuvaus</description>
+            <description lang="en">OpenSubtitles description</description>
+            <resourceShortName lang="en">opensub-fi-2017-korp</resourceShortName>
+            <url>http://urn.fi/urn:nbn:fi:lb-2018060404</url>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2018060403</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-unrestrictedUse</availability>
+            <licenceInfo>
+              <licence>CC-BY</licence>
+              <restrictionsOfUse>attribution</restrictionsOfUse>
+              <distributionAccessMedium>accessibleThroughInterface</distributionAccessMedium>
+              <licensor>
+                <personInfo>
+                  <surname lang="fi">Tutkija</surname>
+                  <givenName lang="fi">Tepi</givenName>
+                  <sex>male</sex>
+                  <communicationInfo>
+                    <email>tepitutkija@example.com</email>
+                  </communicationInfo>
+                  <affiliation>
+                    <organizationName lang="en">University of Helsinki</organizationName>
+                    <organizationShortName lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </affiliation>
+                </personInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <organizationInfo>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </distributionRightsHolder>
+            </licenceInfo>
+            <iprHolder>
+              <surname lang="fi">Tutkija</surname>
+              <givenName lang="fi">Tepi</givenName>
+              <sex>male</sex>
+              <communicationInfo>
+                <email>tepitutkija@example.com</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">University of Helsinki</organizationName>
+                <organizationShortName lang="en">UHEL</organizationShortName>
+                <communicationInfo>
+                  <email>firstname.surname@helsinki.fi</email>
+                </communicationInfo>
+              </affiliation>
+            </iprHolder>
+            <iprHolder>
+              <surname lang="en">Aputoveri</surname>
+              <givenName lang="en">Aarne</givenName>
+              <communicationInfo>
+                <email>aarne.aputoveri@example.com</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">FIN-CLARIN</organizationName>
+                <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+                <departmentName lang="en">University of Helsinki</departmentName>
+                <communicationInfo>
+                  <email>finclarin@helsinki.fi</email>
+                  <url>http://www.helsinki.fi/fin-clarin</url>
+                  <address>PO Box 24 (Unioninkatu 40)</address>
+                  <zipCode>00014</zipCode>
+                  <city>University of Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </iprHolder>
+          </distributionInfo>
+          <contactPerson xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <surname lang="en">FIN-CLARIN</surname>
+            <givenName lang="en">User support</givenName>
+            <communicationInfo>
+              <email>fin-clarin@helsinki.fi</email>
+            </communicationInfo>
+          </contactPerson>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2018-06-04</metadataCreationDate>
+            <metadataCreator>
+              <surname lang="en">Metadataattori</surname>
+              <givenName lang="en">Miina</givenName>
+              <sex>unknown</sex>
+              <communicationInfo>
+                <email>metadatamiina@example.com</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">FIN-CLARIN</organizationName>
+                <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+                <departmentName lang="en">University of Helsinki</departmentName>
+                <communicationInfo>
+                  <email>finclarin@helsinki.fi</email>
+                  <url>http://www.helsinki.fi/fin-clarin</url>
+                  <address>PO Box 24 (Unioninkatu 40)</address>
+                  <zipCode>00014</zipCode>
+                  <city>University of Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <metadataCreator>
+              <surname lang="en">Aputoveri</surname>
+              <givenName lang="en">Aarne</givenName>
+              <communicationInfo>
+                <email>aarne.aputoveri@example.com</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">FIN-CLARIN</organizationName>
+                <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
+                <departmentName lang="en">University of Helsinki</departmentName>
+                <communicationInfo>
+                  <email>finclarin@helsinki.fi</email>
+                  <url>http://www.helsinki.fi/fin-clarin</url>
+                  <address>PO Box 24 (Unioninkatu 40)</address>
+                  <zipCode>00014</zipCode>
+                  <city>University of Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLastDateUpdated>2021-08-13</metadataLastDateUpdated>
+            <revision>Link to resource group page and attribution details added</revision>
+          </metadataInfo>
+          <resourceDocumentationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <documentation>
+              <documentUnstructured>CHANGE LOG 12.11.2019 Added Kielipankki Korp Version to the title</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>CHANGE LOG: 30.1.2020 Availability changed from Restricted to Unrestricted.</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>Resource group page: http://urn.fi/urn:nbn:fi:lb-2021081202</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>How to cite: https://www.kielipankki.fi/viittaus/?key=opensub-fi-2017-korp&amp;lang=en</documentUnstructured>
+            </documentation>
+          </resourceDocumentationInfo>
+          <resourceCreationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceCreator>
+              <personInfo>
+                <surname lang="fi">Tutkija</surname>
+                <givenName lang="fi">Tepi</givenName>
+                <sex>male</sex>
+                <communicationInfo>
+                  <email>tepitutkija@example.com</email>
+                </communicationInfo>
+                <affiliation>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreator>
+          </resourceCreationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>IsVariantFormOf</relationType>
+            <relatedResource>
+              <targetResourceNameURI>http://urn.fi/urn:nbn:fi:lb-2019110801</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <corpusInfo>
+              <resourceType>corpus</resourceType>
+              <corpusMediaType>
+                <corpusTextInfo>
+                  <mediaType>text</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <sizeInfo>
+                    <size>267645406</size>
+                    <sizeUnit>tokens</sizeUnit>
+                  </sizeInfo>
+                  <sizeInfo>
+                    <size>52002003</size>
+                    <sizeUnit>sentences</sizeUnit>
+                  </sizeInfo>
+                </corpusTextInfo>
+              </corpusMediaType>
+            </corpusInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -89,6 +89,7 @@ def test_to_dict(basic_metashare_record):
                 "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
                 "roles": ["creator"],
             },
+            {"person": None, "roles": ["publisher"]},
             {
                 "roles": ["curator"],
                 "person": {
@@ -275,10 +276,14 @@ def test_get_actors(basic_metashare_record):
 
     NB: this is heavily WIP, assuming that the only type of actor implemented is
     curator.
+
+    Publisher role does not yet contain meaningful information due to the test data only
+    having an organization as a distributionRightsHolder and organizations have not been
+    implemented yet.
     """
     actors = basic_metashare_record._get_actors()
 
-    assert len(actors) == 2
+    assert len(actors) == 3
     assert {
         "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
         "roles": ["creator"],
@@ -288,3 +293,5 @@ def test_get_actors(basic_metashare_record):
         "roles": ["curator"],
         "person": {"name": "Mari Siiroinen", "email": "mari.siiroinen@helsinki.fi"},
     } in actors
+
+    assert {"person": None, "roles": ["publisher"]} in actors

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -86,12 +86,16 @@ def test_to_dict(basic_metashare_record):
         },
         "actors": [
             {
+                "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
+                "roles": ["creator"],
+            },
+            {
                 "roles": ["curator"],
                 "person": {
                     "name": "Mari Siiroinen",
                     "email": "mari.siiroinen@helsinki.fi",
                 },
-            }
+            },
         ],
     }
     assert result == expected_result
@@ -274,8 +278,13 @@ def test_get_actors(basic_metashare_record):
     """
     actors = basic_metashare_record._get_actors()
 
-    assert len(actors) == 1
-    assert actors[0] == {
+    assert len(actors) == 2
+    assert {
+        "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
+        "roles": ["creator"],
+    } in actors
+
+    assert {
         "roles": ["curator"],
         "person": {"name": "Mari Siiroinen", "email": "mari.siiroinen@helsinki.fi"},
-    }
+    } in actors

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -97,6 +97,7 @@ def test_to_dict(basic_metashare_record):
                     "email": "mari.siiroinen@helsinki.fi",
                 },
             },
+            {"person": None, "roles": ["rights_holder"]},
         ],
     }
     assert result == expected_result
@@ -283,7 +284,7 @@ def test_get_actors(basic_metashare_record):
     """
     actors = basic_metashare_record._get_actors()
 
-    assert len(actors) == 3
+    assert len(actors) == 4
     assert {
         "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
         "roles": ["creator"],
@@ -295,3 +296,5 @@ def test_get_actors(basic_metashare_record):
     } in actors
 
     assert {"person": None, "roles": ["publisher"]} in actors
+
+    assert {"person": None, "roles": ["rights_holder"]} in actors

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -298,3 +298,52 @@ def test_get_actors(basic_metashare_record):
     assert {"person": None, "roles": ["publisher"]} in actors
 
     assert {"person": None, "roles": ["rights_holder"]} in actors
+
+
+def test_multiple_actors_for_same_role():
+    """
+    Check that having more than one actor for a single role will report them all.
+
+    To be developed further: affiliations missing (KP-7425), and we might want to merge
+    the records for same actor having more than one role.
+    """
+    record = MSRecordParser(
+        _get_file_as_lxml(
+            "tests/test_data/kielipankki_record_sample_multiple_actors.xml"
+        )
+    )
+    assert record._get_actors() == [
+        {
+            "roles": ["creator"],
+            "person": {
+                "name": "Miina Metadataattori",
+                "email": "metadatamiina@example.com",
+            },
+        },
+        {
+            "roles": ["creator"],
+            "person": {
+                "name": "Aarne Aputoveri",
+                "email": "aarne.aputoveri@example.com",
+            },
+        },
+        {"roles": ["publisher"], "person": None},
+        {
+            "roles": ["curator"],
+            "person": {
+                "name": "User support FIN-CLARIN",
+                "email": "fin-clarin@helsinki.fi",
+            },
+        },
+        {
+            "roles": ["rights_holder"],
+            "person": {"name": "Tepi Tutkija", "email": "tepitutkija@example.com"},
+        },
+        {
+            "roles": ["rights_holder"],
+            "person": {
+                "name": "Aarne Aputoveri",
+                "email": "aarne.aputoveri@example.com",
+            },
+        },
+    ]

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -89,7 +89,7 @@ def test_to_dict(basic_metashare_record):
                 "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
                 "roles": ["creator"],
             },
-            {"person": None, "roles": ["publisher"]},
+            {"person": None, "roles": ["publisher", "rights_holder"]},
             {
                 "roles": ["curator"],
                 "person": {
@@ -97,7 +97,6 @@ def test_to_dict(basic_metashare_record):
                     "email": "mari.siiroinen@helsinki.fi",
                 },
             },
-            {"person": None, "roles": ["rights_holder"]},
         ],
     }
     assert result == expected_result
@@ -284,7 +283,7 @@ def test_get_actors(basic_metashare_record):
     """
     actors = basic_metashare_record._get_actors()
 
-    assert len(actors) == 4
+    # assert len(actors) == 4
     assert {
         "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
         "roles": ["creator"],
@@ -295,17 +294,16 @@ def test_get_actors(basic_metashare_record):
         "person": {"name": "Mari Siiroinen", "email": "mari.siiroinen@helsinki.fi"},
     } in actors
 
-    assert {"person": None, "roles": ["publisher"]} in actors
+    # assert {"person": None, "roles": ["publisher"]} in actors
 
-    assert {"person": None, "roles": ["rights_holder"]} in actors
+    # assert {"person": None, "roles": ["rights_holder"]} in actors
 
 
 def test_multiple_actors_for_same_role():
     """
     Check that having more than one actor for a single role will report them all.
 
-    To be developed further: affiliations missing (KP-7425), and we might want to merge
-    the records for same actor having more than one role.
+    To be developed further: affiliations missing (KP-7425)
     """
     record = MSRecordParser(
         _get_file_as_lxml(
@@ -321,7 +319,7 @@ def test_multiple_actors_for_same_role():
             },
         },
         {
-            "roles": ["creator"],
+            "roles": ["creator", "rights_holder"],
             "person": {
                 "name": "Aarne Aputoveri",
                 "email": "aarne.aputoveri@example.com",
@@ -338,12 +336,5 @@ def test_multiple_actors_for_same_role():
         {
             "roles": ["rights_holder"],
             "person": {"name": "Tepi Tutkija", "email": "tepitutkija@example.com"},
-        },
-        {
-            "roles": ["rights_holder"],
-            "person": {
-                "name": "Aarne Aputoveri",
-                "email": "aarne.aputoveri@example.com",
-            },
         },
     ]

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -84,6 +84,15 @@ def test_to_dict(basic_metashare_record):
                 "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
             },
         },
+        "actors": [
+            {
+                "roles": ["curator"],
+                "person": {
+                    "name": "Mari Siiroinen",
+                    "email": "mari.siiroinen@helsinki.fi",
+                },
+            }
+        ],
     }
     assert result == expected_result
 
@@ -253,3 +262,20 @@ def test_get_resource_languages_with_multiple_languages():
     language_urls = [language["url"] for language in languages]
     assert "http://lexvo.org/id/iso639-5/smi" in language_urls
     assert "http://lexvo.org/id/iso639-3/swe" in language_urls
+
+
+def test_get_actors(basic_metashare_record):
+    """
+    Check that all actor data is present in a Metax-compatible format for a basic
+    record.
+
+    NB: this is heavily WIP, assuming that the only type of actor implemented is
+    curator.
+    """
+    actors = basic_metashare_record._get_actors()
+
+    assert len(actors) == 1
+    assert actors[0] == {
+        "roles": ["curator"],
+        "person": {"name": "Mari Siiroinen", "email": "mari.siiroinen@helsinki.fi"},
+    }

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -89,7 +89,6 @@ def test_to_dict(basic_metashare_record):
                 "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
                 "roles": ["creator"],
             },
-            {"person": None, "roles": ["publisher", "rights_holder"]},
             {
                 "roles": ["curator"],
                 "person": {
@@ -283,7 +282,7 @@ def test_get_actors(basic_metashare_record):
     """
     actors = basic_metashare_record._get_actors()
 
-    # assert len(actors) == 4
+    assert len(actors) == 2
     assert {
         "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
         "roles": ["creator"],
@@ -293,10 +292,6 @@ def test_get_actors(basic_metashare_record):
         "roles": ["curator"],
         "person": {"name": "Mari Siiroinen", "email": "mari.siiroinen@helsinki.fi"},
     } in actors
-
-    # assert {"person": None, "roles": ["publisher"]} in actors
-
-    # assert {"person": None, "roles": ["rights_holder"]} in actors
 
 
 def test_multiple_actors_for_same_role():
@@ -325,7 +320,6 @@ def test_multiple_actors_for_same_role():
                 "email": "aarne.aputoveri@example.com",
             },
         },
-        {"roles": ["publisher"], "person": None},
         {
             "roles": ["curator"],
             "person": {


### PR DESCRIPTION
Now adding actors for curator, creator, publisher and rights_holder roles in Metax. These are created from Metashare metadata as described in [Kielipankki-Metax v3 mapping](https://wiki.eduuni.fi/pages/viewpage.action?spaceKey=cscfairdata&title=Kielipankki+-+Metax+V3+Mapping). Metax would also support contributor role, but that is not used.

Same person holding multiple roles is represented as a single actor with multiple roles.

Currently we also get actors with no data besides a role, which does not make sense. This will change when [KP-7425](https://jira.eduuni.fi/browse/KP-7425) is implemented and they get an organization.