### PR TITLE
KP-7427 Make tests always start with an empty Metax language code cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from lxml import etree
 import pytest
 import requests_mock
 
+from harvester import language_validator
 from harvester.metadata_parser import MSRecordParser
 from metax_api import MetaxAPI
 
@@ -412,6 +413,7 @@ def mock_metax_language_vocabulary_endpoint(
     The response dicts are also somewhat trimmed down, because we don't need the full
     data with all translations.
     """
+    language_validator._allowed_language_uris.cache_clear()
     with open("tests/test_data/metax_language_vocabulary.json", "r") as response_json:
         data = json.loads(response_json.read())
     shared_request_mocker.get(language_vocabulary_endpoint_url, json=data)

--- a/tests/harvester/test_pmh_interface.py
+++ b/tests/harvester/test_pmh_interface.py
@@ -18,7 +18,7 @@ def test_fetch_records_with_last_harvest_date(
     assert records == mock_metashare_get_single_record
     assert (
         urllib.parse.quote(latest_harvest_timestamp)
-        in shared_request_mocker.last_request.url
+        in shared_request_mocker.request_history[0].url
     )
 
 

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -165,10 +165,10 @@ def test_full_harvest_all_data_harvested_and_records_in_sync(
 
     assert result.exit_code == 0
 
-    assert mock_requests_post.call_count == 5
-    assert mock_requests_post.request_history[2].method == "POST"
+    assert mock_requests_post.call_count == 6
+    assert mock_requests_post.request_history[3].method == "POST"
     assert (
-        mock_requests_post.request_history[2].json()["persistent_identifier"]
+        mock_requests_post.request_history[3].json()["persistent_identifier"]
         == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
@@ -201,6 +201,7 @@ def test_full_harvest_all_data_harvested_and_records_not_in_sync(
     Expected requests made during this test:
     GET to fetch the records from Metashare (for adding new records)
     GET to get the Metax PID (found)
+    GET to determine which language codes are accepted by Metax
     PUT to to update the data in Metax
     GET to fetch the records from Metashare (again, for deleted records this time)
     GET to fetch the records from Metax (no overlap, so no further requests)
@@ -210,10 +211,10 @@ def test_full_harvest_all_data_harvested_and_records_not_in_sync(
 
     assert result.exit_code == 0
 
-    assert mock_requests_put.call_count == 5
-    assert mock_requests_put.request_history[2].method == "PUT"
+    assert mock_requests_put.call_count == 6
+    assert mock_requests_put.request_history[3].method == "PUT"
     assert (
-        mock_requests_put.request_history[2].json()["persistent_identifier"]
+        mock_requests_put.request_history[3].json()["persistent_identifier"]
         == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
@@ -246,10 +247,10 @@ def test_full_harvest_new_records_harvested_since_date_and_records_in_sync(
 
     assert result.exit_code == 0
 
-    assert mock_requests_post.call_count == 5
-    assert mock_requests_post.request_history[2].method == "POST"
+    assert mock_requests_post.call_count == 6
+    assert mock_requests_post.request_history[3].method == "POST"
     assert (
-        mock_requests_post.request_history[2].json()["persistent_identifier"]
+        mock_requests_post.request_history[3].json()["persistent_identifier"]
         == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
@@ -292,10 +293,10 @@ def test_full_harvest_changed_records_harvested_since_date_and_records_not_in_sy
 
     assert result.exit_code == 0
 
-    assert mock_requests_put.call_count == 7
-    assert mock_requests_put.request_history[2].method == "PUT"
+    assert mock_requests_put.call_count == 8
+    assert mock_requests_put.request_history[3].method == "PUT"
     assert (
-        mock_requests_put.request_history[2].json()["persistent_identifier"]
+        mock_requests_put.request_history[3].json()["persistent_identifier"]
         == mock_metashare_get_single_record[0]["persistent_identifier"]
     )
 
@@ -330,7 +331,7 @@ def test_full_harvest_multiple_records(
 
     assert result.exit_code == 0
 
-    assert shared_request_mocker.call_count == 11
+    assert shared_request_mocker.call_count == 12
     assert (
         sum(
             request.method == "POST"
@@ -368,7 +369,7 @@ def test_full_harvest_without_log_file(shared_request_mocker, run_cli):
 
     assert result.exit_code == 0
 
-    assert shared_request_mocker.call_count == 11
+    assert shared_request_mocker.call_count == 12
     assert (
         sum(
             request.method == "POST"

--- a/tests/test_metax_api.py
+++ b/tests/test_metax_api.py
@@ -212,15 +212,16 @@ def test_send_record(
     """
     Check that creating one new metadata record works
 
-    This means that Metax is queried for existence of the PID (not found) and then a new
-    record is POSTed. We also check that the posted data corresponds to the record dict
-    passed to the function.
+    This means that Metax is queried for existence of the PID (not found), metadata is
+    made into a Metax-compatible dict (causing the Metax API to be queried for allowed
+    language codes) and then a new record is POSTed. We also check that the posted data
+    corresponds to the record dict passed to the function.
     """
     metax_api.send_record(basic_metashare_record)
 
-    assert shared_request_mocker.call_count == 2
+    assert shared_request_mocker.call_count == 3
 
-    expected_post_request = shared_request_mocker.request_history[1]
+    expected_post_request = shared_request_mocker.request_history[2]
 
     assert expected_post_request.method == "POST"
     assert expected_post_request.json() == basic_metashare_record.to_dict()
@@ -238,15 +239,16 @@ def test_send_data_to_metax_single_pre_existing_record(
     """
     Check that creating one new metadata record works
 
-    This means that Metax is queried for existence of the PID (found), fetches the Metax
-    ID for the record, and then a new record is PUT. We also check that the posted
+    This means that Metax is queried for existence of the PID (found), metadata is
+    made into a Metax-compatible dict (causing the Metax API to be queried for allowed
+    language codes) and then a new record is PUT. We also check that the posted
     data corresponds to the record dict passed to the function.
     """
     metax_api.send_record(basic_metashare_record)
 
-    assert shared_request_mocker.call_count == 2
+    assert shared_request_mocker.call_count == 3
 
-    expected_put_request = shared_request_mocker.request_history[1]
+    expected_put_request = shared_request_mocker.request_history[2]
 
     assert expected_put_request.method == "PUT"
     assert expected_put_request.json() == basic_metashare_record.to_dict()


### PR DESCRIPTION
If the cache is not cleared between tests that use it, the number of HTTP requests made during a test depends on which tests have been run earlier, which makes the tests brittle. Now each test should pass independently.