### PR TITLE
KP-7425 Add organization for actors

### DIFF
--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -17,15 +17,6 @@ class Actor:
 
         self.roles = set(roles)
 
-    def _language(self, element):
-        """
-        Return language of given element from `lang` attribute. None if not present.
-        """
-        for attribute in element.items():
-            if attribute[0] == "lang":
-                return attribute[1]
-        return None
-
     def _etree_to_dict(self, element):
         """
         Convert the XML data describing this actor into a dict
@@ -64,8 +55,8 @@ class Actor:
         result = {}
         key = re.sub("{.*}", "", element.tag)
         if len(element) == 0:
-            language = self._language(element)
-            if self._language(element):
+            language = element.attrib.get("lang", None)
+            if language:
                 key = key + "_" + language
             result[key] = element.text
         else:

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -80,6 +80,7 @@ class Actor:
                 return f"{self.data['givenName'+'_'+language]} {self.data['surname'+'_'+language]}"
             if f"surname_{language}" in self.data:
                 return f"{self.data['surname'+'_'+language]}"
+        return None
 
     @property
     def email(self):
@@ -120,8 +121,7 @@ class Actor:
         """
         if self.name:
             return {"name": self.name, "email": self.email}
-        else:
-            return None
+        return None
 
     @property
     def has_person_data(self):

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -249,13 +249,18 @@ class Actor:
         """
         Check if two objects represent the same person.
 
-        The actors are deemed equal if their names and emails match. This allows merging
-        the entries of same person having multiple roles.
+        The actors are deemed equal if their names, emails and organizations match. This
+        allows merging the entries of same person having multiple roles. The same
+        natural person having represented different organizations will not be merged.
         """
         if not isinstance(other, Actor):
             return False
 
-        return self.name == other.name and self.email == other.email
+        return (
+            self.name == other.name
+            and self.email == other.email
+            and self._organization_dict == other._organization_dict
+        )
 
 
 class UnknownOrganizationException(Exception):

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -106,7 +106,7 @@ class Actor:
         at most).
         """
         return {
-            "roles": sorted(list(self.roles)),
+            "roles": sorted(self.roles),
             "person": self._person_dict,
             "organization": self._organization_dict,
         }

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -72,7 +72,7 @@ class Actor:
         """
         Return name of the person represented by this actor.
 
-        If the name is provided in more than one language, only one is returned, fields
+        If the name is provided in more than one language, only one is returned,
         preference order being determined by the order of `self.supported_languages`.
         """
         for language in self.supported_languages:
@@ -86,8 +86,8 @@ class Actor:
         """
         Email address of the person. None if not available.
         """
-        communicationInfo = self.data.get("communicationInfo", {})
-        return communicationInfo.get("email", None)
+        communication_info = self.data.get("communicationInfo", {})
+        return communication_info.get("email", None)
 
     def add_roles(self, roles):
         """

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -92,8 +92,20 @@ class Actor:
 
     @property
     def _organization_url(self):
+        """
+        Return URI for the affiliation of this actor.
+
+        The URIs are from http://uri.suomi.fi/codelist/fairdata/organization/code. For
+        FIN-CLARIAH affiliations, the home organization from the `departmentName` field
+        is used when determining the URI.
+
+        Raises UnknownOrganizationException if URI match is not found.
+        """
 
         organization_name = self.data["affiliation"]["organizationName"]
+
+        if organization_name == "FIN-CLARIN":
+            organization_name = self.data["affiliation"]["departmentName"]
 
         url_base = "http://uri.suomi.fi/codelist/fairdata/organization/code"
         organization_codes = {

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -10,7 +10,7 @@ class Actor:
         use. The root element (e.g. "contactPerson") is omitted, because that
         information is already included in `roles`.
         """
-        self.supported_languages = ["fi", "en", "und"]
+        self.supported_languages = ["en", "fi", "und"]
         self.data = self._etree_to_dict(element)
         if len(self.data) == 1:
             self.data = list(self.data.values())[0]

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -68,6 +68,12 @@ class Actor:
 
     @property
     def _person_dict(self):
+        """
+        Return personal information about the actor as a Metax-compatible dict.
+
+        If the actor is not a person or personal information is otherwise not available,
+        None is returned.
+        """
         if self.name:
             return {"name": self.name, "email": self.email}
         else:

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -91,7 +91,7 @@ class Actor:
         return self._person_dict is not None
 
     @property
-    def _organization_url(self):
+    def _organization_uri(self):
         """
         Return URI for the affiliation of this actor.
 
@@ -139,7 +139,7 @@ class Actor:
             return None
 
         try:
-            return {"url": self._organization_url}
+            return {"url": self._organization_uri}
         except UnknownOrganizationException as e:
             # TODO: this should be eliminated before this ticket is done
             print(e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,6 +336,7 @@ def mock_metashare_get_single_record(
             },
             "actors": [
                 {
+                    "organization": None,
                     "person": {
                         "email": "imre.bartis@helsinki.fi",
                         "name": "Imre Bartis",
@@ -343,6 +344,9 @@ def mock_metashare_get_single_record(
                     "roles": ["creator"],
                 },
                 {
+                    "organization": {
+                        "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+                    },
                     "roles": ["curator"],
                     "person": {
                         "name": "Mari Siiroinen",

--- a/tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml
+++ b/tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml
@@ -1,0 +1,140 @@
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2023-08-10T06:22:09Z</responseDate>
+  <request verb="GetRecord" identifier="oai:kielipankki.fi:sh41ac60" metadataPrefix="info">https://kielipankki.fi/md_api/que</request>
+  <GetRecord>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/">
+      <header>
+        <identifier>oai:kielipankki.fi:sh41ac60</identifier>
+        <datestamp>2022-11-17T04:02:11Z</datestamp>
+      </header>
+      <metadata>
+        <info:resourceInfo xmlns:info="http://www.ilsp.gr/META-XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ilsp.gr/META-XMLSchema http://metashare.ilsp.gr/META-XMLSchema/v3.0/META-SHARE-Resource.xsd">
+          <identificationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceName lang="fi">Suomenkielinen OpenSubtitles 2017, Kielipankin Korp-versio</resourceName>
+            <resourceName lang="en">Finnish OpenSubtitles 2017, Kielipankki Korp Version</resourceName>
+            <description lang="fi">OpenSubtitles kuvaus</description>
+            <description lang="en">OpenSubtitles description</description>
+            <resourceShortName lang="en">opensub-fi-2017-korp</resourceShortName>
+            <url>http://urn.fi/urn:nbn:fi:lb-2018060404</url>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2018060403</identifier>
+          </identificationInfo>
+          <distributionInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <availability>available-unrestrictedUse</availability>
+            <licenceInfo>
+              <licence>CC-BY</licence>
+              <restrictionsOfUse>attribution</restrictionsOfUse>
+              <distributionAccessMedium>accessibleThroughInterface</distributionAccessMedium>
+              <licensor>
+                <personInfo>
+                  <surname lang="fi">Tutkija</surname>
+                  <givenName lang="fi">Tepi</givenName>
+                  <sex>male</sex>
+                  <communicationInfo>
+                    <email>tepitutkija@example.com</email>
+                  </communicationInfo>
+                  <affiliation>
+                    <organizationName lang="en">University of Helsinki</organizationName>
+                    <organizationShortName lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </affiliation>
+                </personInfo>
+              </licensor>
+              <distributionRightsHolder>
+                <organizationInfo>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </distributionRightsHolder>
+            </licenceInfo>
+            <iprHolder>
+              <surname lang="en">Bernadotte</surname>
+              <givenName lang="en">Carl Gustaf</givenName>
+              <surname lang="fi">Bernadotte</surname>
+              <givenName lang="fi">Kaarle Kustaa</givenName>
+              <communicationInfo>
+                <email>kungen@example.com</email>
+              </communicationInfo>
+            </iprHolder>
+          </distributionInfo>
+          <metadataInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <metadataCreationDate>2018-06-04</metadataCreationDate>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLastDateUpdated>2021-08-13</metadataLastDateUpdated>
+            <revision>Link to resource group page and attribution details added</revision>
+          </metadataInfo>
+          <resourceDocumentationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <documentation>
+              <documentUnstructured>CHANGE LOG 12.11.2019 Added Kielipankki Korp Version to the title</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>CHANGE LOG: 30.1.2020 Availability changed from Restricted to Unrestricted.</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>Resource group page: http://urn.fi/urn:nbn:fi:lb-2021081202</documentUnstructured>
+            </documentation>
+            <documentation>
+              <documentUnstructured>How to cite: https://www.kielipankki.fi/viittaus/?key=opensub-fi-2017-korp&amp;lang=en</documentUnstructured>
+            </documentation>
+          </resourceDocumentationInfo>
+          <resourceCreationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <resourceCreator>
+              <personInfo>
+                <surname lang="fi">Tutkija</surname>
+                <givenName lang="fi">Tepi</givenName>
+                <sex>male</sex>
+                <communicationInfo>
+                  <email>tepitutkija@example.com</email>
+                </communicationInfo>
+                <affiliation>
+                  <organizationName lang="en">University of Helsinki</organizationName>
+                  <organizationShortName lang="en">UHEL</organizationShortName>
+                  <communicationInfo>
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreator>
+          </resourceCreationInfo>
+          <relationInfo xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <relationType>IsVariantFormOf</relationType>
+            <relatedResource>
+              <targetResourceNameURI>http://urn.fi/urn:nbn:fi:lb-2019110801</targetResourceNameURI>
+            </relatedResource>
+          </relationInfo>
+          <resourceComponentType xmlns="http://www.ilsp.gr/META-XMLSchema">
+            <corpusInfo>
+              <resourceType>corpus</resourceType>
+              <corpusMediaType>
+                <corpusTextInfo>
+                  <mediaType>text</mediaType>
+                  <lingualityInfo>
+                    <lingualityType>monolingual</lingualityType>
+                  </lingualityInfo>
+                  <languageInfo>
+                    <languageId>fi</languageId>
+                    <languageName>Finnish</languageName>
+                  </languageInfo>
+                  <sizeInfo>
+                    <size>267645406</size>
+                    <sizeUnit>tokens</sizeUnit>
+                  </sizeInfo>
+                  <sizeInfo>
+                    <size>52002003</size>
+                    <sizeUnit>sentences</sizeUnit>
+                  </sizeInfo>
+                </corpusTextInfo>
+              </corpusMediaType>
+            </corpusInfo>
+          </resourceComponentType>
+        </info:resourceInfo>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/tests/test_data/kielipankki_record_sample_multiple_actors.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_actors.xml
@@ -107,7 +107,7 @@
               <affiliation>
                 <organizationName lang="en">FIN-CLARIN</organizationName>
                 <organizationShortName lang="en">FIN-CLARIN</organizationShortName>
-                <departmentName lang="en">University of Helsinki</departmentName>
+                <departmentName lang="en">University of Turku</departmentName>
                 <communicationInfo>
                   <email>finclarin@helsinki.fi</email>
                   <url>http://www.helsinki.fi/fin-clarin</url>

--- a/tests/test_data/kielipankki_record_sample_multiple_actors.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_actors.xml
@@ -138,6 +138,23 @@
                 </communicationInfo>
               </affiliation>
             </metadataCreator>
+            <metadataCreator>
+              <surname lang="en">Affiliaattori</surname>
+              <givenName lang="en">Amanda</givenName>
+              <communicationInfo>
+                <email>aaffil@example.com</email>
+              </communicationInfo>
+              <affiliation>
+                <organizationName lang="en">Imaginary organization</organizationName>
+                <organizationName lang="fi">Kuvitteellinen organisaatio</organizationName>
+                <organizationShortName lang="en">imag-org</organizationShortName>
+                <departmentName lang="en">Department of Investigations</departmentName>
+                <communicationInfo>
+                  <email>imaginary@example.com</email>
+                  <url>http://www.imaginary.example</url>
+                </communicationInfo>
+              </affiliation>
+            </metadataCreator>
             <metadataLanguageName>English</metadataLanguageName>
             <metadataLanguageId>en</metadataLanguageId>
             <metadataLastDateUpdated>2021-08-13</metadataLastDateUpdated>

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -362,3 +362,21 @@ def test_multiple_actors_for_same_role():
             },
         },
     ]
+
+
+def test_multiple_names_for_actor():
+    """
+    Check that having the name in more than one language will result in Finnish name
+    being preferred.
+
+    The test data for this test would also have the English name "Carl Gustaf"
+    available, but the Finnish "Kaarle Kustaa" should be preferred.
+    """
+    record = MSRecordParser(
+        _get_file_as_lxml(
+            "tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml"
+        )
+    )
+    actors = record._get_actors()
+    assert len(actors) == 1
+    assert actors[0]["person"]["name"] == "Kaarle Kustaa Bernadotte"

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -369,8 +369,8 @@ def test_multiple_names_for_actor():
     Check that having the name in more than one language will result in Finnish name
     being preferred.
 
-    The test data for this test would also have the English name "Carl Gustaf"
-    available, but the Finnish "Kaarle Kustaa" should be preferred.
+    The test data for this test would also have the Finnish name "Kaarle Kustaa"
+    available, but the English "Carl Gustaf" should be preferred.
     """
     record = MSRecordParser(
         _get_file_as_lxml(
@@ -379,4 +379,4 @@ def test_multiple_names_for_actor():
     )
     actors = record._get_actors()
     assert len(actors) == 1
-    assert actors[0]["person"]["name"] == "Kaarle Kustaa Bernadotte"
+    assert actors[0]["person"]["name"] == "Carl Gustaf Bernadotte"

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -88,12 +88,16 @@ def test_to_dict(basic_metashare_record):
             {
                 "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
                 "roles": ["creator"],
+                "organization": None,
             },
             {
                 "roles": ["curator"],
                 "person": {
                     "name": "Mari Siiroinen",
                     "email": "mari.siiroinen@helsinki.fi",
+                },
+                "organization": {
+                    "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
                 },
             },
         ],
@@ -273,9 +277,6 @@ def test_get_actors(basic_metashare_record):
     Check that all actor data is present in a Metax-compatible format for a basic
     record.
 
-    NB: this is heavily WIP, assuming that the only type of actor implemented is
-    curator.
-
     Publisher role does not yet contain meaningful information due to the test data only
     having an organization as a distributionRightsHolder and organizations have not been
     implemented yet.
@@ -286,11 +287,15 @@ def test_get_actors(basic_metashare_record):
     assert {
         "person": {"email": "imre.bartis@helsinki.fi", "name": "Imre Bartis"},
         "roles": ["creator"],
+        "organization": None,
     } in actors
 
     assert {
         "roles": ["curator"],
         "person": {"name": "Mari Siiroinen", "email": "mari.siiroinen@helsinki.fi"},
+        "organization": {
+            "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
+        },
     } in actors
 
 
@@ -312,6 +317,7 @@ def test_multiple_actors_for_same_role():
                 "name": "Miina Metadataattori",
                 "email": "metadatamiina@example.com",
             },
+            "organization": None,
         },
         {
             "roles": ["creator", "rights_holder"],
@@ -319,6 +325,7 @@ def test_multiple_actors_for_same_role():
                 "name": "Aarne Aputoveri",
                 "email": "aarne.aputoveri@example.com",
             },
+            "organization": None,
         },
         {
             "roles": ["curator"],
@@ -326,9 +333,13 @@ def test_multiple_actors_for_same_role():
                 "name": "User support FIN-CLARIN",
                 "email": "fin-clarin@helsinki.fi",
             },
+            "organization": None,
         },
         {
             "roles": ["rights_holder"],
             "person": {"name": "Tepi Tutkija", "email": "tepitutkija@example.com"},
+            "organization": {
+                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+            },
         },
     ]

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -317,7 +317,9 @@ def test_multiple_actors_for_same_role():
                 "name": "Miina Metadataattori",
                 "email": "metadatamiina@example.com",
             },
-            "organization": None,
+            "organization": {
+                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/10089"
+            },
         },
         {
             "roles": ["creator", "rights_holder"],
@@ -325,7 +327,9 @@ def test_multiple_actors_for_same_role():
                 "name": "Aarne Aputoveri",
                 "email": "aarne.aputoveri@example.com",
             },
-            "organization": None,
+            "organization": {
+                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
+            },
         },
         {
             "roles": ["curator"],

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -332,6 +332,23 @@ def test_multiple_actors_for_same_role():
             },
         },
         {
+            "organization": {
+                "email": "imaginary@example.com",
+                "homepage": {"identifier": "http://www.imaginary.example"},
+                "pref_label": {
+                    "en": "Imaginary organization",
+                    "fi": "Kuvitteellinen organisaatio",
+                },
+            },
+            "person": {
+                "email": "aaffil@example.com",
+                "name": "Amanda Affiliaattori",
+            },
+            "roles": [
+                "creator",
+            ],
+        },
+        {
             "roles": ["curator"],
             "person": {
                 "name": "User support FIN-CLARIN",

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -302,8 +302,6 @@ def test_get_actors(basic_metashare_record):
 def test_multiple_actors_for_same_role():
     """
     Check that having more than one actor for a single role will report them all.
-
-    To be developed further: affiliations missing (KP-7425)
     """
     record = MSRecordParser(
         _get_file_as_lxml(


### PR DESCRIPTION
The manual mapping allows using URIs for Finnish research organizations present in http://uri.suomi.fi/codelist/fairdata/organization. These match https://metax.fd-rework.csc.fi/v3/organizations.

For organizations that are not present in the code list, we provide name (in Finnish and English if available), homepage (if available) and an email address. The source data could have more than one email address or homepage for an organization, but Metax only accepts one: the last in the metadata is chosen due to that being convenient.

Parsing the language variants for different fields also required some changes to the pre-existing code that handles actor names and the general XML parsing for actors. The `givenName` and `surname` fields can also be repeated for different languages (e.g. `<givenName lang="fi">Yrjö</givenName>` and `<givenName lang="en">George</givenName>` for the same person). Previously the last field encountered was the one that was chosen, whereas now we do a conscious choice to choose the name to be sent to Metax in order English, Finnish, undefined.

Adding new big test files is not great, but as this is likely the last one we need in the foreseeable future, it didn't seem worth it to build a system for e.g. generating the Metashare response XML on the fly.