### PR TITLE
KP-7380 Make the code Python 3.6 compatible

### DIFF
--- a/harvester/language_validator.py
+++ b/harvester/language_validator.py
@@ -7,7 +7,7 @@ import functools
 import requests
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def _allowed_language_uris(language_vocabulary_endpoint):
     """
     Return a list of allowed language URIs from the given endpoint.


### PR DESCRIPTION
CentOS 7 only offers Python versions up to 3.6 by default, so until we migrate the OSes, it's easiest if this is 3.6 compatible. Unfortunately there's no automatic testing for 3.6, and setting it up might not make that much sense either due to OS update being right behind a corner.