### PR TITLE
KP-7441 Report errors to stdout for email notifications

### DIFF
--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -83,7 +83,7 @@ class Actor:
             if f"givenName_{language}" in person_info:
                 return f"{person_info['givenName'+'_'+language]} {person_info['surname'+'_'+language]}"
             if f"surname_{language}" in person_info:
-                return f"person_info['surname'+'_'+language]"
+                return f"{person_info['surname'+'_'+language]}"
         return None
 
     @property

--- a/harvester/actor.py
+++ b/harvester/actor.py
@@ -220,7 +220,7 @@ class Actor:
     @_none_if_person_witout_affiliation
     def organization_name(self):
         """
-        Return the nameis of the organizaton in all supported and provided languages.
+        Return the names of the organizaton in all supported and provided languages.
 
         The element is mandatory in the profile we use, so handling for missing key is
         not needed, but there can be multiple language versions, each of which is sent

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -323,10 +323,11 @@ class RecordParser:
 
                 for curator_element in curator_elements:
                     new_actor = Actor(curator_element, roles=[role])
-                    # TODO: replace this with handling for actors without (mandatory)
-                    # organization
-                    # if not new_actor.has_person_data:
-                    #    continue
+                    if not new_actor.organization_name:
+                        raise RecordParsingError(
+                            f"Could not find affiliation for {new_actor.name}", self.pid
+                        )
+
                     try:
                         if new_actor in actors:
                             actors[actors.index(new_actor)].add_roles(new_actor.roles)

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -153,21 +153,25 @@ def full_harvest(config_file):
 
     if not faulty_records:
         if harvested_date:
-            logger_harvester.info("Success, records harvested since %s", harvested_date)
+            logger_harvester.info(
+                "Success, %d records harvested since %s", total_records, harvested_date
+            )
         else:
-            logger_harvester.info("Success, all records harvested")
+            logger_harvester.info("Success, %d records harvested", total_records)
     else:
         if harvested_date:
             logger_harvester.info(
-                "Success, records harvested since %s (%d faulty record not uploaded and will "
-                "not be automatically retried)",
+                "Success, %d records harvested since %s (out of which %d faulty "
+                "record(s) not uploaded and will not be automatically retried)",
+                total_records,
                 harvested_date,
                 faulty_records,
             )
         else:
             logger_harvester.info(
-                "Success, all records harvested (%d faulty record not uploaded and will not "
+                "Success, %d records harvested (%d faulty record(s) not uploaded and will not "
                 "be automatically retried)",
+                total_records,
                 faulty_records,
             )
 

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -131,7 +131,7 @@ def full_harvest(config_file):
             click.echo(
                 f"There seems to be a configuration error related to Metax URL: {err}"
             )
-            return
+            raise click.Abort()
         except HTTPError as err:
             faulty_records += 1
             click.echo(
@@ -142,7 +142,6 @@ def full_harvest(config_file):
                 f"response text: {err.response.text}, "
                 f"payload: {err.request.body}"
             )
-            return
         except RequestException as err:
             faulty_records += 1
             click.echo(f"Error making a HTTP request: {err}")
@@ -182,6 +181,7 @@ def full_harvest(config_file):
             f"Error when determining records to be removed from Metax: {err}. Deletion of further "
             "records will not be attempted."
         )
+        raise click.Abort()
     except HTTPError as err:
         click.echo(
             "Error deleting a record from Metax. Deletion of further records will not "
@@ -192,14 +192,20 @@ def full_harvest(config_file):
             f"response text: {err.response.text}, "
             f"payload: {err.request.body}"
         )
+        raise click.Abort()
     except RequestException as err:
         click.echo(
             "Error deleting a record from Metax. Deletion of further records will not "
             f"be attempted: {err}"
         )
+        raise click.Abort()
     except:  # pylint: disable=bare-except
         click.echo("Unexpected problem when deleting a record from Metax:")
         click.echo(traceback.format_exc())
+        raise click.Abort()
+
+    if faulty_records:
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -146,8 +146,8 @@ def full_harvest(config_file):
             )
         except RequestException as error:
             faulty_records += 1
-        except:  # pylint: disable=bare-except
             click.echo(f"Error making a HTTP request: {error}", err=True)
+        except Exception:
             faulty_records += 1
             click.echo(f"Unexpected problem with {record.pid}:", err=True)
             click.echo(traceback.format_exc(), err=True)
@@ -205,7 +205,7 @@ def full_harvest(config_file):
             err=True,
         )
         raise click.Abort()
-    except:  # pylint: disable=bare-except
+    except Exception:
         click.echo("Unexpected problem when deleting a record from Metax:", err=True)
         click.echo(traceback.format_exc(), err=True)
         raise click.Abort()

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -123,31 +123,31 @@ def full_harvest(config_file):
 
         try:
             destination_api.send_record(record)
-        except RecordParsingError as err:
+        except RecordParsingError as error:
             faulty_records += 1
-            click.echo(err, err=True)
-        except (MissingSchema, InvalidSchema, InvalidURL) as err:
+            click.echo(error, err=True)
+        except (MissingSchema, InvalidSchema, InvalidURL) as error:
             faulty_records += 1
             click.echo(
-                f"There seems to be a configuration error related to Metax URL: {err}",
+                f"There seems to be a configuration error related to Metax URL: {error}",
                 err=True,
             )
             raise click.Abort()
-        except HTTPError as err:
+        except HTTPError as error:
             faulty_records += 1
             click.echo(
                 "HTTP request failed. "
-                f"method: {err.request.method}, "
-                f"URL: {err.request.url}, "
-                f'error: "{err}", '
-                f"response text: {err.response.text}, "
-                f"payload: {err.request.body}",
+                f"method: {error.request.method}, "
+                f"URL: {error.request.url}, "
+                f'error: "{error}", '
+                f"response text: {error.response.text}, "
+                f"payload: {error.request.body}",
                 err=True,
             )
-        except RequestException as err:
+        except RequestException as error:
             faulty_records += 1
-            click.echo(f"Error making a HTTP request: {err}", err=True)
         except:  # pylint: disable=bare-except
+            click.echo(f"Error making a HTTP request: {error}", err=True)
             faulty_records += 1
             click.echo(f"Unexpected problem with {record.pid}:", err=True)
             click.echo(traceback.format_exc(), err=True)
@@ -179,29 +179,29 @@ def full_harvest(config_file):
 
     try:
         destination_api.delete_records_not_in(source_api.fetch_records())
-    except RecordParsingError as err:
+    except RecordParsingError as error:
         click.echo(
-            f"Error when determining records to be removed from Metax: {err}. Deletion of further "
+            f"Error when determining records to be removed from Metax: {error}. Deletion of further "
             "records will not be attempted.",
             err=True,
         )
         raise click.Abort()
-    except HTTPError as err:
+    except HTTPError as error:
         click.echo(
             "Error deleting a record from Metax. Deletion of further records will not "
             "be attempted. "
-            f"method: {err.request.method}, "
-            f"URL: {err.request.url}, "
-            f'error: "{err}", '
-            f"response text: {err.response.text}, "
-            f"payload: {err.request.body}",
+            f"method: {error.request.method}, "
+            f"URL: {error.request.url}, "
+            f'error: "{error}", '
+            f"response text: {error.response.text}, "
+            f"payload: {error.request.body}",
             err=True,
         )
         raise click.Abort()
-    except RequestException as err:
+    except RequestException as error:
         click.echo(
             "Error deleting a record from Metax. Deletion of further records will not "
-            f"be attempted: {err}",
+            f"be attempted: {error}",
             err=True,
         )
         raise click.Abort()

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -149,6 +149,7 @@ def full_harvest(config_file):
             faulty_records += 1
             click.echo(f"Unexpected problem with {record.pid}:")
             click.echo(traceback.format_exc())
+            raise click.Abort()
 
     if not faulty_records:
         if harvested_date:

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -175,7 +175,31 @@ def full_harvest(config_file):
                 faulty_records,
             )
 
-    destination_api.delete_records_not_in(source_api.fetch_records())
+    try:
+        destination_api.delete_records_not_in(source_api.fetch_records())
+    except RecordParsingError as err:
+        click.echo(
+            f"Error when determining records to be removed from Metax: {err}. Deletion of further "
+            "records will not be attempted."
+        )
+    except HTTPError as err:
+        click.echo(
+            "Error deleting a record from Metax. Deletion of further records will not "
+            "be attempted. "
+            f"method: {err.request.method}, "
+            f"URL: {err.request.url}, "
+            f'error: "{err}", '
+            f"response text: {err.response.text}, "
+            f"payload: {err.request.body}"
+        )
+    except RequestException as err:
+        click.echo(
+            "Error deleting a record from Metax. Deletion of further records will not "
+            f"be attempted: {err}"
+        )
+    except:  # pylint: disable=bare-except
+        click.echo("Unexpected problem when deleting a record from Metax:")
+        click.echo(traceback.format_exc())
 
 
 if __name__ == "__main__":

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -2,8 +2,11 @@
 Main script for running metadata harvesting and sending it to Metax.
 """
 
-import logging
 from datetime import datetime
+import logging
+import traceback
+
+import click
 from requests.exceptions import (
     MissingSchema,
     InvalidSchema,
@@ -11,9 +14,6 @@ from requests.exceptions import (
     HTTPError,
     RequestException,
 )
-import traceback
-
-import click
 import yaml
 
 from harvester.metadata_parser import RecordParsingError

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -125,11 +125,12 @@ def full_harvest(config_file):
             destination_api.send_record(record)
         except RecordParsingError as err:
             faulty_records += 1
-            click.echo(err)
+            click.echo(err, err=True)
         except (MissingSchema, InvalidSchema, InvalidURL) as err:
             faulty_records += 1
             click.echo(
-                f"There seems to be a configuration error related to Metax URL: {err}"
+                f"There seems to be a configuration error related to Metax URL: {err}",
+                err=True,
             )
             raise click.Abort()
         except HTTPError as err:
@@ -140,15 +141,16 @@ def full_harvest(config_file):
                 f"URL: {err.request.url}, "
                 f'error: "{err}", '
                 f"response text: {err.response.text}, "
-                f"payload: {err.request.body}"
+                f"payload: {err.request.body}",
+                err=True,
             )
         except RequestException as err:
             faulty_records += 1
-            click.echo(f"Error making a HTTP request: {err}")
+            click.echo(f"Error making a HTTP request: {err}", err=True)
         except:  # pylint: disable=bare-except
             faulty_records += 1
-            click.echo(f"Unexpected problem with {record.pid}:")
-            click.echo(traceback.format_exc())
+            click.echo(f"Unexpected problem with {record.pid}:", err=True)
+            click.echo(traceback.format_exc(), err=True)
             raise click.Abort()
 
     if not faulty_records:
@@ -180,7 +182,8 @@ def full_harvest(config_file):
     except RecordParsingError as err:
         click.echo(
             f"Error when determining records to be removed from Metax: {err}. Deletion of further "
-            "records will not be attempted."
+            "records will not be attempted.",
+            err=True,
         )
         raise click.Abort()
     except HTTPError as err:
@@ -191,18 +194,20 @@ def full_harvest(config_file):
             f"URL: {err.request.url}, "
             f'error: "{err}", '
             f"response text: {err.response.text}, "
-            f"payload: {err.request.body}"
+            f"payload: {err.request.body}",
+            err=True,
         )
         raise click.Abort()
     except RequestException as err:
         click.echo(
             "Error deleting a record from Metax. Deletion of further records will not "
-            f"be attempted: {err}"
+            f"be attempted: {err}",
+            err=True,
         )
         raise click.Abort()
     except:  # pylint: disable=bare-except
-        click.echo("Unexpected problem when deleting a record from Metax:")
-        click.echo(traceback.format_exc())
+        click.echo("Unexpected problem when deleting a record from Metax:", err=True)
+        click.echo(traceback.format_exc(), err=True)
         raise click.Abort()
 
     if faulty_records:

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -151,10 +151,25 @@ def full_harvest(config_file):
             click.echo(f"Unexpected problem with {record.pid}:")
             click.echo(traceback.format_exc())
 
-    if harvested_date:
-        logger_harvester.info("Success, records harvested since %s", harvested_date)
+    if not faulty_records:
+        if harvested_date:
+            logger_harvester.info("Success, records harvested since %s", harvested_date)
+        else:
+            logger_harvester.info("Success, all records harvested")
     else:
-        logger_harvester.info("Success, all records harvested")
+        if harvested_date:
+            logger_harvester.info(
+                "Success, records harvested since %s (%d faulty record not uploaded and will "
+                "not be automatically retried)",
+                harvested_date,
+                faulty_records,
+            )
+        else:
+            logger_harvester.info(
+                "Success, all records harvested (%d faulty record not uploaded and will not "
+                "be automatically retried)",
+                faulty_records,
+            )
 
     destination_api.delete_records_not_in(source_api.fetch_records())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,9 @@ def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
             },
             "actors": [
                 {
-                    "organization": None,
+                    "organization": {
+                        "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+                    },
                     "person": {
                         "email": "miina@example.com",
                         "name": "Miina Metadataaja",

--- a/tests/test_data/comedi_list_records_multiple.xml
+++ b/tests/test_data/comedi_list_records_multiple.xml
@@ -118,6 +118,20 @@
                       <city>Helsinki</city>
                       <country>Finland</country>
                     </communicationInfo>
+                    <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                      <role>affiliation</role>
+                      <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <departmentName xml:lang="en">
+                          Department of Finnish, Finno-Ugrian and Scandinavian Studies
+                        </departmentName>
+                        <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                          <email>kiia@example.com</email>
+                          <url>http://www.helsinki.fi/fus/index.htm</url>
+                          <country>Finland</country>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
@@ -497,11 +511,25 @@
               <contactPerson ComponentId="clarin.eu:cr1:c_1352813745468">
                 <role>contactPerson</role>
                 <personInfo ComponentId="clarin.eu:cr1:c_1349361150746">
-                  <surname xml:lang="en">FIN-CLARIN</surname>
-                  <givenName xml:lang="en">User support</givenName>
+                  <surname xml:lang="en">Keijo</surname>
+                  <givenName xml:lang="en">Kontakti</givenName>
                   <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
-                    <email>fin-clarin@helsinki.fi</email>
+                    <email>keijo@example.com</email>
                   </communicationInfo>
+                  <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                    <role>affiliation</role>
+                    <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                      <organizationName xml:lang="en">University of Helsinki</organizationName>
+                      <departmentName xml:lang="en">
+                        Department of Finnish, Finno-Ugrian and Scandinavian Studies
+                      </departmentName>
+                      <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                        <email>kiia@example.com</email>
+                        <url>http://www.helsinki.fi/fus/index.htm</url>
+                        <country>Finland</country>
+                      </communicationInfo>
+                    </organizationInfo>
+                  </affiliation>
                 </personInfo>
               </contactPerson>
               <metadataInfo ComponentId="clarin.eu:cr1:c_1349361150745">
@@ -913,6 +941,20 @@
                   <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
                     <email>fin-clarin@helsinki.fi</email>
                   </communicationInfo>
+                  <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                    <role>affiliation</role>
+                    <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                      <organizationName xml:lang="en">University of Helsinki</organizationName>
+                      <departmentName xml:lang="en">
+                        Department of Finnish, Finno-Ugrian and Scandinavian Studies
+                      </departmentName>
+                      <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                        <email>kiia@example.com</email>
+                        <url>http://www.helsinki.fi/fus/index.htm</url>
+                        <country>Finland</country>
+                      </communicationInfo>
+                    </organizationInfo>
+                  </affiliation>
                 </personInfo>
               </contactPerson>
               <metadataInfo ComponentId="clarin.eu:cr1:c_1349361150745">

--- a/tests/test_data/comedi_list_records_single.xml
+++ b/tests/test_data/comedi_list_records_single.xml
@@ -119,6 +119,20 @@
                       <city>Helsinki</city>
                       <country>Finland</country>
                     </communicationInfo>
+                    <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                      <role>affiliation</role>
+                      <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <departmentName xml:lang="en">
+                          Department of Finnish, Finno-Ugrian and Scandinavian Studies
+                        </departmentName>
+                        <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                          <email>kiia@example.com</email>
+                          <url>http://www.helsinki.fi/fus/index.htm</url>
+                          <country>Finland</country>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>

--- a/tests/test_data/kielipankki_record_sample.xml
+++ b/tests/test_data/kielipankki_record_sample.xml
@@ -114,6 +114,20 @@
                   <city>Helsinki</city>
                   <country>Finland</country>
                 </communicationInfo>
+                <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                  <role>affiliation</role>
+                  <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                    <organizationName xml:lang="en">University of Helsinki</organizationName>
+                    <departmentName xml:lang="en">
+                      Department of Finnish, Finno-Ugrian and Scandinavian Studies
+                    </departmentName>
+                    <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                      <email>finno-ugrian@example.com</email>
+                      <url>http://www.helsinki.fi/fus/index.htm</url>
+                      <country>Finland</country>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
               </personInfo>
             </metadataCreator>
           </metadataInfo>

--- a/tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml
+++ b/tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml
@@ -82,6 +82,15 @@
                 <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
                   <email>kungen@example.com</email>
                 </communicationInfo>
+                <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">The Royal Palaces</organizationName>
+                    <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                      <email>firstname.lastname@example.com</email>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
               </personInfo>
             </iprHolderPerson>
           </distributionInfo>

--- a/tests/test_data/kielipankki_record_sample_multiple_actors.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_actors.xml
@@ -133,11 +133,27 @@
           <contactPerson ComponentId="clarin.eu:cr1:c_1352813745468">
             <role>contactPerson</role>
             <personInfo ComponentId="clarin.eu:cr1:c_1349361150746">
-              <surname xml:lang="en">FIN-CLARIN</surname>
-              <givenName xml:lang="en">User support</givenName>
+              <surname xml:lang="en">Kuraattori</surname>
+              <givenName xml:lang="en">Kari</givenName>
               <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
-                <email>fin-clarin@helsinki.fi</email>
+                <email>kari@example.com</email>
               </communicationInfo>
+              <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                <role>affiliation</role>
+                <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                  <organizationName xml:lang="en">FIN-CLARIN</organizationName>
+                  <organizationShortName xml:lang="en">FIN-CLARIN</organizationShortName>
+                  <departmentName xml:lang="en">University of Helsinki</departmentName>
+                  <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                    <email>finclarin@helsinki.fi</email>
+                    <url>http://www.helsinki.fi/fin-clarin</url>
+                    <address>PO Box 24 (Unioninkatu 40)</address>
+                    <zipCode>00014</zipCode>
+                    <city>University of Helsinki</city>
+                    <country>Finland</country>
+                  </communicationInfo>
+                </organizationInfo>
+              </affiliation>
             </personInfo>
           </contactPerson>
           <metadataInfo ComponentId="clarin.eu:cr1:c_1349361150745">

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -172,7 +172,8 @@ def test_full_harvest_all_data_harvested_and_records_in_sync(
         == mock_list_records_single_record[0]["persistent_identifier"]
     )
 
-    assert "Success, all records harvested" in caplog.text
+    assert "Success, 1 records harvested" in caplog.text
+    assert "faulty" not in caplog.text
 
 
 @pytest.mark.usefixtures(
@@ -218,7 +219,8 @@ def test_full_harvest_all_data_harvested_and_records_not_in_sync(
         == mock_list_records_single_record[0]["persistent_identifier"]
     )
 
-    assert "Success, all records harvested" in caplog.text
+    assert "Success, 1 records harvested" in caplog.text
+    assert "faulty" not in caplog.text
 
 
 @pytest.mark.usefixtures(
@@ -254,7 +256,8 @@ def test_full_harvest_new_records_harvested_since_date_and_records_in_sync(
         == mock_list_records_single_record[0]["persistent_identifier"]
     )
 
-    assert "Success, records harvested since" in caplog.text
+    assert "Success, 1 records harvested since" in caplog.text
+    assert "faulty" not in caplog.text
 
 
 @pytest.mark.usefixtures(
@@ -300,7 +303,8 @@ def test_full_harvest_changed_records_harvested_since_date_and_records_not_in_sy
         == mock_list_records_single_record[0]["persistent_identifier"]
     )
 
-    assert "Success, records harvested since" in caplog.text
+    assert "Success, 1 records harvested since" in caplog.text
+    assert "faulty" not in caplog.text
 
 
 @pytest.mark.usefixtures(

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -1,6 +1,6 @@
 import pytest
 from lxml import etree
-from harvester.metadata_parser import RecordParser
+from harvester.metadata_parser import RecordParser, RecordParsingError
 
 
 def _get_file_as_lxml(filename):
@@ -245,9 +245,12 @@ def missing_pid_record():
 
 def test_missing_pid_reported_as_error(missing_pid_record):
     """Check that a missing PID is handled."""
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(RecordParsingError) as err:
         missing_pid_record.pid()
-    assert str(err.value) == "No pid found for record oai:clarino.uib.no:lb-2017021609"
+    assert (
+        str(err.value)
+        == "Error parsing record oai:clarino.uib.no:lb-2017021609: Could not determine PID"
+    )
 
 
 def test_get_resource_languages(basic_cmdi_record):

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -86,7 +86,9 @@ def test_to_dict(basic_cmdi_record, dataset_pid, kielipankki_datacatalog_id):
             {
                 "person": {"email": "miina@example.com", "name": "Miina Metadataaja"},
                 "roles": ["creator"],
-                "organization": None,
+                "organization": {
+                    "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
+                },
             },
             {
                 "roles": ["publisher", "rights_holder"],
@@ -299,7 +301,9 @@ def test_get_actors(basic_cmdi_record):
     assert {
         "person": {"email": "miina@example.com", "name": "Miina Metadataaja"},
         "roles": ["creator"],
-        "organization": None,
+        "organization": {
+            "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
+        },
     } in actors
 
     assert {
@@ -374,10 +378,12 @@ def test_multiple_actors_for_same_role():
         {
             "roles": ["curator"],
             "person": {
-                "name": "User support FIN-CLARIN",
-                "email": "fin-clarin@helsinki.fi",
+                "name": "Kari Kuraattori",
+                "email": "kari@example.com",
             },
-            "organization": None,
+            "organization": {
+                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+            },
         },
         {
             "roles": ["rights_holder"],


### PR DESCRIPTION
Error messages are now produced to stdout (the same pattern we use in our other error notifications mailed from cronjobs) from all "risky" operations (i.e. ones which involve network communications or user-generated data). Hopefully reasonably debug-helpful messages are achieved by exception handling. This makes the CLI code a bit copypastey, but also allows not messing around with the actual business logic too much. If unexpected errors are encountered, a full stack trace is produced instead.

We are also able to halt execution if we encounter unexpected or unrecoverable errors (e.g. misconfiguration from a conf file will be misconfiguration for all records, no need to loop through them all) while progressing to the next record if individual faulty records are encountered. If there are any errors when deleting records, the program is also halted immediately due to the inherently more risky nature of deletion operations. This is also indicated for the reader of the output by the "Aborted!" message generated by click.

If there are errors that are more likely to be record-specific (e.g. record not parseable or not accepted by Metax), the program is allowed to run through and produce the harvester_log line indicating that the unchanged records do not need to be reprocessed on next run, but the exit code will still be non-zero. The number of problematic records will also be indicated in harvester_log, e.g. `Success, 574 records harvested (2 faulty record(s) not uploaded and will not be automatically retried)`.

Because we know that Metax won't accept persons without affiliation, it doesn't make sense to even offer such records to Metax. Instead, an error is raised already during record parsing, allowing us to report the error in the way we see fit.

TODO:
- [x] Handle https://github.com/CSCfi/Kielipankki-Metax-bridge/pull/24 first, this assumes it has already been merged