### PR TITLE
KP-8261 Fixes required before going to production

### DIFF
--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -443,4 +443,5 @@ class RecordParser:
             "created": self._get_datetime("//cmd:Header/cmd:MdCreationDate/text()"),
             "access_rights": self._map_access_rights(),
             "actors": self._get_actors(),
+            "state": "published",
         }

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -253,10 +253,8 @@ class RecordParser:
         access_type = self._get_access_type()
         if (
             access_type["url"]
-            == "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
-        ):
-            restriction_grounds_urls = []
-        elif not restriction_grounds_urls:
+            == "http://uri.suomi.fi/codelist/fairdata/access_type/code/restricted"
+        ) and not restriction_grounds_urls:
             restriction_grounds_urls.add(
                 "http://uri.suomi.fi/codelist/fairdata/restriction_grounds/code/other"
             )

--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -69,13 +69,6 @@ class RecordParser:
         """
         return self.xml.xpath(xpath, namespaces=self.namespaces)[0]
 
-    def _get_identifier(self, xpath):
-        """
-        Retrieves the urn of the given XPath's url.
-        """
-        identifier_urn = self._get_text_xpath(xpath).strip()
-        return f"urn.fi/{identifier_urn}"
-
     def _get_datetime(self, xpath):
         """
         Retrieve the datetime from given XPath as a string (YYYY-mm-ddTHH:MM:SSZ).
@@ -100,7 +93,7 @@ class RecordParser:
         Return the PID for this record
         """
         try:
-            return self._get_identifier("//cmd:Header/cmd:MdSelfLink/text()")
+            return self._get_text_xpath("//cmd:Header/cmd:MdSelfLink/text()").strip()
         except IndexError:
             comedi_identifier = self._get_text_xpath(
                 "//oai:header/oai:identifier/text()"

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -96,7 +96,13 @@ def _config_from_file(config_file):
 
 @click.command()
 @click.argument("config_file", type=click.File("r"), default="config/config.yml")
-def full_harvest(config_file):
+@click.option(
+    "--pause-between-records",
+    is_flag=True,
+    default=False,
+    help="Ask for confirmation before progressing to the next record",
+)
+def full_harvest(config_file, pause_between_records):
     """
     Runs the whole pipeline of fetching data since last harvest and sending it to Metax.
 
@@ -152,6 +158,18 @@ def full_harvest(config_file):
             click.echo(f"Unexpected problem with {record.pid}:", err=True)
             click.echo(traceback.format_exc(), err=True)
             raise click.Abort()
+
+        if pause_between_records:
+            click.echo(f"Processed {record.pid}")
+            selection = click.prompt(
+                "Continue?",
+                type=click.Choice(["next", "all", "abort"]),
+                show_choices=True,
+            )
+            if selection == "abort":
+                raise click.Abort()
+            if selection == "all":
+                pause_between_records = False
 
     if not faulty_records:
         if harvested_date:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,6 +362,7 @@ def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
                     },
                 },
             ],
+            "state": "published",
         }
     ]
 
@@ -424,6 +425,7 @@ def mock_cmdi_get_single_record(
                     },
                 },
             ],
+            "state": "published",
         }
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def mock_get_response_json():
 @pytest.fixture
 def dataset_pid():
     """Return PID of sample record."""
-    return "urn.fi/urn:nbn:fi:lb-2017021609"
+    return "urn:nbn:fi:lb-2017021609"
 
 
 @pytest.fixture
@@ -285,10 +285,10 @@ def mock_corpus_pid_list_from_cmdi(
     """
     shared_request_mocker.get(kielipankki_api_url, text=cmdi_multiple_records_xml)
     return [
-        "urn.fi/urn:nbn:fi:lb-2017021609",
-        "urn.fi/urn:nbn:fi:lb-20140730196",
-        "urn.fi/urn:nbn:fi:lb-2018060403",
-        "urn.fi/urn:nbn:fi:lb-2019121004",
+        "urn:nbn:fi:lb-2017021609",
+        "urn:nbn:fi:lb-20140730196",
+        "urn:nbn:fi:lb-2018060403",
+        "urn:nbn:fi:lb-2019121004",
     ]
 
 
@@ -310,7 +310,7 @@ def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
             "field_of_science": [
                 {"url": "http://www.yso.fi/onto/okm-tieteenala/ta6121"}
             ],
-            "persistent_identifier": "urn.fi/urn:nbn:fi:lb-2017021609",
+            "persistent_identifier": "urn:nbn:fi:lb-2017021609",
             "title": {
                 "en": "Silva Kiuru's Time Expressions Corpus",
                 "fi": "Silva Kiurun ajanilmausaineisto",
@@ -384,7 +384,7 @@ def mock_cmdi_get_single_record(
             "field_of_science": [
                 {"url": "http://www.yso.fi/onto/okm-tieteenala/ta6121"}
             ],
-            "persistent_identifier": "urn.fi/urn:nbn:fi:lb-2017021609",
+            "persistent_identifier": "urn:nbn:fi:lb-2017021609",
             "title": {
                 "en": "Silva Kiuru's Time Expressions Corpus",
                 "fi": "Silva Kiurun ajanilmausaineisto",

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -107,6 +107,7 @@ def test_to_dict(basic_cmdi_record, dataset_pid, kielipankki_datacatalog_id):
                 },
             },
         ],
+        "state": "published",
     }
     assert result == expected_result
 


### PR DESCRIPTION
Fixed issues / improvements:
1. Metax defaults to everything being unpublished, meaning that the records are not viewable without the creator's API token. We want ours to be public.
2. Fairdata services expect persistent identifiers (preferred identifiers in old API vocabulary) to not have the urn.fi part (see e.g. [metax v1 search results in our catalogue](https://metax.fairdata.fi/rest/datasets?data_catalog=urn%3Anbn%3Afi%3Aatt%3Adata-catalog-harvest-kielipankki&limit=10&include_legacy=false)), and we need to comply with that to be able to identify records when updating from old harvests.
3. Option to run the bridge one record at a time: this allows us to verify a couple of records exported to production before overwriting everything.
4. Remove unnecessary restriction grounds logic for ACA + availableUnrestrictedUse (does not occur in our metadata, nor should it occur in the future)