### PR TITLE
KP-9470 pipeline update

### DIFF
--- a/.github/workflows/python-pipeline.yml
+++ b/.github/workflows/python-pipeline.yml
@@ -17,16 +17,16 @@ jobs:
   black:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v4
-    - name: Install required Python packages
-      run: python3.8 -m pip install black --user
-    - name: Check formatting with Black
-      run: python3.8 -m black --check .
+      - uses: actions/checkout@v4
+      - name: Install required Python packages
+        run: python3.8 -m pip install black --user
+      - name: Check formatting with Black
+        run: python3.8 -m black --check .
   unit-test:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v4
-    - name: Install required Python packages
-      run: python3.8 -m pip install -r requirements_dev.txt --user
-    - name: Test with pytest
-      run: python3.8 -m pytest
+      - uses: actions/checkout@v4
+      - name: Install required Python packages
+        run: python3.8 -m pip install -r requirements_dev.txt --user
+      - name: Test with pytest
+        run: python3.8 -m pytest

--- a/.github/workflows/python-pipeline.yml
+++ b/.github/workflows/python-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
   black:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install required Python packages
       run: python3.8 -m pip install black --user
     - name: Check formatting with Black
@@ -25,7 +25,7 @@ jobs:
   unit-test:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install required Python packages
       run: python3.8 -m pip install -r requirements_dev.txt --user
     - name: Test with pytest


### PR DESCRIPTION
The old one is old enough to produce the following warning to the pipeline view:
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/