### PR TITLE
KP-9517 Produce a neat error message when metadata doesn't have a creator

### DIFF
--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -324,6 +324,10 @@ class RecordParser:
         """
         Return the actors for this resource.
 
+        Metax requires at least one creator and exactly one publisher for each dataset,
+        while Comedi does not enforce any limits on these, so an error is raised if
+        these are not found in the source data.
+
         NB: due to Metax requiring there to be exactly one publisher for each dataset,
         we need to adjust some actor sets.
         """
@@ -366,6 +370,11 @@ class RecordParser:
                         UnableToParseOrganizationInfoException,
                     ) as err:
                         raise RecordParsingError(str(err), self.pid)
+
+        if sum(1 for actor in actors if "creator" in actor.roles) == 0:
+            raise RecordParsingError(
+                "No metadata creators (creator in Metax) found", self.pid
+            )
 
         publisher_actors = sum(1 for actor in actors if "publisher" in actor.roles)
         if publisher_actors == 0:

--- a/tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml
+++ b/tests/test_data/kielipankki_record_sample_actor_with_multiple_names.xml
@@ -124,6 +124,37 @@
             <revision>
               Link to resource group page and attribution details added
             </revision>
+            <metadataCreator>
+              <role>metadataCreator</role>
+              <personInfo>
+                <surname xml:lang="en">Metadataaja</surname>
+                <givenName xml:lang="en">Miina</givenName>
+                <sex>male</sex>
+                <position>Project Coordinator</position>
+                <communicationInfo>
+                  <email>miina@example.com</email>
+                  <url>http://orcid.org/0000-0002-9455-8771</url>
+                  <city>Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+                <affiliation>
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">FIN-CLARIN</organizationName>
+                    <organizationShortName xml:lang="en">FIN-CLARIN</organizationShortName>
+                    <departmentName xml:lang="en">University of Helsinki</departmentName>
+                    <communicationInfo>
+                      <email>finclarin@helsinki.fi</email>
+                      <url>http://www.helsinki.fi/fin-clarin</url>
+                      <address>PO Box 24 (Unioninkatu 40)</address>
+                      <zipCode>00014</zipCode>
+                      <city>University of Helsinki</city>
+                      <country>Finland</country>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </metadataCreator>
           </metadataInfo>
           <resourceDocumentationInfo ComponentId="clarin.eu:cr1:c_1355150532301">
             <documentationUnstructured ComponentId="clarin.eu:cr1:c_1355150532302">

--- a/tests/test_data/kielipankki_record_sample_no_creator.xml
+++ b/tests/test_data/kielipankki_record_sample_no_creator.xml
@@ -1,0 +1,134 @@
+<record xmlns="http://www.openarchives.org/OAI/2.0/">
+  <header>
+    <identifier>oai:clarino.uib.no:lb-2017021609</identifier>
+    <datestamp>2024-06-19T07:38:46Z</datestamp>
+    <setSpec>FIN-CLARIN</setSpec>
+  </header>
+  <metadata>
+    <CMD xmlns="http://www.clarin.eu/cmd/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CMDVersion="1.1" xsi:schemaLocation="http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1361876010571/xsd">
+      <Header>
+        <MdCreator>metashareToCmdi.xsl remove_metashare_namespace.xsl</MdCreator>
+        <MdCreationDate>2022-09-02</MdCreationDate>
+        <MdSelfLink>urn:nbn:fi:lb-2017021609</MdSelfLink>
+        <MdProfile>clarin.eu:cr1:p_1361876010571</MdProfile>
+      </Header>
+      <Resources>
+        <ResourceProxyList/>
+        <JournalFileProxyList/>
+        <ResourceRelationList/>
+        <IsPartOfList/>
+      </Resources>
+      <Components>
+        <resourceInfo>
+          <identificationInfo ComponentId="clarin.eu:cr1:c_1349361150743">
+            <resourceName xml:lang="fi">Silva Kiurun ajanilmausaineisto</resourceName>
+            <resourceName xml:lang="en">Silva Kiuru's Time Expressions Corpus</resourceName>
+            <description xml:lang="fi">
+              Tämä suomen kielen ajanilmauksia käsittävä aineisto on koottu kaunokirjallisten alkuperäisteosten, käännösten, murreaineistojen ja muiden tekstien pohjalta.
+            </description>
+            <description xml:lang="en">
+              This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.
+            </description>
+            <metaShareId>NOT_DEFINED_FOR_V2</metaShareId>
+            <identifier>http://urn.fi/urn:nbn:fi:lb-2017021609</identifier>
+          </identificationInfo>
+          <distributionInfo ComponentId="clarin.eu:cr1:c_1352813745459">
+            <availability>available-unrestrictedUse</availability>
+            <licenceInfo ComponentId="clarin.eu:cr1:c_1352813745464">
+              <licence>underNegotiation</licence>
+              <licensorOrganization ComponentId="clarin.eu:cr1:c_1361876010643">
+                <role>licensor</role>
+                <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                  <organizationName xml:lang="en">University of Helsinki</organizationName>
+                  <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                  <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </licensorOrganization>
+              <distributionRightsHolderOrganization ComponentId="clarin.eu:cr1:c_1361876010640">
+                <role>distributionRightsHolder</role>
+                <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                  <organizationName xml:lang="en">University of Helsinki</organizationName>
+                  <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                  <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                    <email>firstname.surname@helsinki.fi</email>
+                  </communicationInfo>
+                </organizationInfo>
+              </distributionRightsHolderOrganization>
+            </licenceInfo>
+            <iprHolderOrganization ComponentId="clarin.eu:cr1:c_1361876010642">
+              <role>iprHolder</role>
+              <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                <organizationName xml:lang="en">University of Helsinki</organizationName>
+                <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                  <email>firstname.surname@helsinki.fi</email>
+                </communicationInfo>
+              </organizationInfo>
+            </iprHolderOrganization>
+          </distributionInfo>
+          <contactPerson ComponentId="clarin.eu:cr1:c_1352813745468">
+            <role>contactPerson</role>
+            <personInfo ComponentId="clarin.eu:cr1:c_1349361150746">
+              <surname xml:lang="en">Kontakti</surname>
+              <givenName xml:lang="en">Kiia</givenName>
+              <sex>female</sex>
+              <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                <email>kiia@example.com</email>
+                <country>Finland</country>
+              </communicationInfo>
+              <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                <role>affiliation</role>
+                <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                  <organizationName xml:lang="en">University of Helsinki</organizationName>
+                  <departmentName xml:lang="en">
+                    Department of Finnish, Finno-Ugrian and Scandinavian Studies
+                  </departmentName>
+                  <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                    <email>finno-ugrian@example.com</email>
+                    <url>http://www.helsinki.fi/fus/index.htm</url>
+                    <country>Finland</country>
+                  </communicationInfo>
+                </organizationInfo>
+              </affiliation>
+            </personInfo>
+          </contactPerson>
+          <metadataInfo ComponentId="clarin.eu:cr1:c_1349361150745">
+            <metadataCreationDate>2017-02-15</metadataCreationDate>
+            <metadataLanguageName>English</metadataLanguageName>
+            <metadataLanguageName>Finnish</metadataLanguageName>
+            <metadataLanguageId>en</metadataLanguageId>
+            <metadataLanguageId>fi</metadataLanguageId>
+            <metadataLastDateUpdated>2017-02-15</metadataLastDateUpdated>
+          </metadataInfo>
+          <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
+            <resourceType>corpus</resourceType>
+            <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">
+              <corpusTextInfo ComponentId="clarin.eu:cr1:c_1355150532311">
+                <mediaType>text</mediaType>
+                <lingualityInfo ComponentId="clarin.eu:cr1:c_1355150532313">
+                  <lingualityType>monolingual</lingualityType>
+                </lingualityInfo>
+                <languageInfo ComponentId="clarin.eu:cr1:c_1355150532314">
+                  <languageId>fi</languageId>
+                  <languageName>Finnish</languageName>
+                </languageInfo>
+                <modalityInfo ComponentId="clarin.eu:cr1:c_1355150532318">
+                  <modalityType>writtenLanguage</modalityType>
+                </modalityInfo>
+                <sizeInfo ComponentId="clarin.eu:cr1:c_1353678848785">
+                  <size>1</size>
+                  <sizeUnit>other</sizeUnit>
+                </sizeInfo>
+                <textFormatInfo ComponentId="clarin.eu:cr1:c_1355150532320">
+                  <mimeType>application/msword</mimeType>
+                </textFormatInfo>
+              </corpusTextInfo>
+            </corpusMediaType>
+          </corpusInfo>
+        </resourceInfo>
+      </Components>
+    </CMD>
+  </metadata>
+</record>

--- a/tests/test_data/kielipankki_record_sample_with_publisher_person.xml
+++ b/tests/test_data/kielipankki_record_sample_with_publisher_person.xml
@@ -149,6 +149,37 @@
             <metadataLanguageId>Fi</metadataLanguageId>
             <metadataLanguageId>en</metadataLanguageId>
             <metadataLastDateUpdated>2014-04-24</metadataLastDateUpdated>
+            <metadataCreator>
+              <role>metadataCreator</role>
+              <personInfo>
+                <surname xml:lang="en">Metadataaja</surname>
+                <givenName xml:lang="en">Miina</givenName>
+                <sex>male</sex>
+                <position>Project Coordinator</position>
+                <communicationInfo>
+                  <email>miina@example.com</email>
+                  <url>http://orcid.org/0000-0002-9455-8771</url>
+                  <city>Helsinki</city>
+                  <country>Finland</country>
+                </communicationInfo>
+                <affiliation>
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">FIN-CLARIN</organizationName>
+                    <organizationShortName xml:lang="en">FIN-CLARIN</organizationShortName>
+                    <departmentName xml:lang="en">University of Helsinki</departmentName>
+                    <communicationInfo>
+                      <email>finclarin@helsinki.fi</email>
+                      <url>http://www.helsinki.fi/fin-clarin</url>
+                      <address>PO Box 24 (Unioninkatu 40)</address>
+                      <zipCode>00014</zipCode>
+                      <city>University of Helsinki</city>
+                      <country>Finland</country>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </metadataCreator>
           </metadataInfo>
           <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
             <resourceType>corpus</resourceType>

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -456,8 +456,8 @@ def test_multiple_names_for_actor():
         )
     )
     actors = record._get_actors()
-    assert len(actors) == 1
-    assert actors[0]["person"]["name"] == "Carl Gustaf Bernadotte"
+    assert len(actors) == 2
+    assert actors[1]["person"]["name"] == "Carl Gustaf Bernadotte"
 
 
 def test_publisher_person():
@@ -473,9 +473,9 @@ def test_publisher_person():
         )
     )
     actors = record.to_dict(data_catalog="catalog_id")["actors"]
-    assert len(actors) == 1
-    assert "publisher" in actors[0]["roles"]
-    assert actors[0]["person"]["name"] == "Late Lisensoija"
+    assert len(actors) == 2
+    assert "publisher" in actors[1]["roles"]
+    assert actors[1]["person"]["name"] == "Late Lisensoija"
 
 
 def test_finclarin_organization_code_is_helsinki_uni():
@@ -492,3 +492,14 @@ def test_finclarin_organization_code_is_helsinki_uni():
         actors[0]["organization"]["url"]
         == "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
     )
+
+
+def test_missing_creator_reported():
+    """
+    Verify that we don't try to send records without creator to Metax.
+    """
+    record = RecordParser(
+        _get_file_as_lxml("tests/test_data/kielipankki_record_sample_no_creator.xml")
+    )
+    with pytest.raises(RecordParsingError):
+        record.to_dict(data_catalog="catalog_id")


### PR DESCRIPTION
Metax won't accept creatorless records, so it's better to produce a readable report than to rely on the quite verbose catch-all Metax export failure message.

Other tests were affected too, because one of our test files was lacking a metadata creator.