### PR TITLE
KP-9691 Allow reporting extra records without automatic deletion

### DIFF
--- a/metax_api.py
+++ b/metax_api.py
@@ -96,6 +96,15 @@ class MetaxAPI:
         else:
             self.create_record(record.to_dict(data_catalog=self.catalog_id))
 
+    def pids_to_be_deleted(self, retained_records):
+        """
+        Return a list of PIDs for records that should be deleted from Metax.
+
+        Retained records are expected as an iterable of RecordParser instances.
+        """
+        retained_pids = {record.pid for record in retained_records}
+        return self.datacatalog_record_pids.difference(retained_pids)
+
     def delete_records_not_in(self, retained_records):
         """
         Delete all records whose PIDs are not present in `retained_records`.
@@ -106,9 +115,7 @@ class MetaxAPI:
 
         :retained_records: iterable containing all the records that must not be deleted.
         """
-        retained_pids = {record.pid for record in retained_records}
-        pids_to_be_deleted = self.datacatalog_record_pids.difference(retained_pids)
-        for pid in pids_to_be_deleted:
+        for pid in self.pids_to_be_deleted(retained_records):
             self.delete_record(self.record_id(pid))
 
     def create_record(self, data):

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -128,15 +128,16 @@ def run_cli(basic_configuration):
     converted.
     """
 
-    def _run_cli(configuration_file_path=None):
+    def _run_cli(configuration_file_path=None, extra_args=None):
         if configuration_file_path is None:
             configuration_file_path = basic_configuration
 
-        runner = CliRunner()
-        return runner.invoke(
-            full_harvest,
-            [str(configuration_file_path)],
-        )
+        required_args = [str(configuration_file_path)]
+        if not extra_args:
+            extra_args = []
+
+        runner = CliRunner(mix_stderr=False)
+        return runner.invoke(full_harvest, required_args + extra_args)
 
     return _run_cli
 


### PR DESCRIPTION
To play it safe, we want our cronjobs to only report the need for deleting records instead of actually deleting the records. These changes make the CLI tool default to just listing the records to be deleted. If the list looks sensible, the tool can still carry out the deletion operations if explicitly told to do so by providing the `--automatic-delete` flag.