### PR TITLE
KP-9760 Default to demo instead of fd-rework API endpoints

### DIFF
--- a/config/template.yml
+++ b/config/template.yml
@@ -1,7 +1,7 @@
 ---
 metax_api_token: filltokenhere
-metax_base_url: https://metax.fd-rework.csc.fi/v3
-metax_catalog_id: urn:nbn:fi:att:data-catalog-kielipankki
+metax_base_url: https://metax.demo.fairdata.fi/v3
+metax_catalog_id: urn:nbn:fi:att:data-catalog-harvest-kielipankki
 
 harvester_log_file: logs/harvester.log
 metax_api_log_file: logs/metax_api_requests.log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def _get_file_as_string(filename):
 @pytest.fixture
 def metax_base_url():
     """Metax API"""
-    return "https://metax.fd-rework.csc.fi/v3"
+    return "https://metax.demo.fairdata.fi/v3"
 
 
 @pytest.fixture

--- a/tests/test_metadata_harvester_cli.py
+++ b/tests/test_metadata_harvester_cli.py
@@ -62,7 +62,7 @@ def basic_configuration(
     return create_test_config_file(
         {
             "metax_api_token": "apitokentestvalue",
-            "metax_base_url": "https://metax.fd-rework.csc.fi/v3",
+            "metax_base_url": "https://metax.demo.fairdata.fi/v3",
             "metax_catalog_id": "urn:nbn:fi:att:data-catalog-kielipankki",
             "harvester_log_file": str(default_test_log_file_path),
             "metax_api_log_file": str(default_metax_api_log_file_path),
@@ -469,7 +469,7 @@ def test_cli_reporting_missing_configuration_values(create_test_config_file, run
     create_test_config_file(
         {
             "metax_api_token": "qwerty",
-            "metax_base_url": "https://metax.fd-rework.csc.fi/",
+            "metax_base_url": "https://metax.demo.fairdata.fi/",
             "metax_catalog_id": "abc123",
             # harvester_log_file not defined
             "metax_api_log_file": "log.txt",


### PR DESCRIPTION
Fairdata team is deprecating the old fd-rework.csc.fi, so we must also start using metax.demo.fairdata.fi, so it seems reasonable to reflect this in the configuration example too to avoid possible confusion in the future.

In demo environment, our data catalog also changes so that it now matches the production one.

Adjusting the tests would not be strictly necessary as there the URL does not need to match that of the real service, but it's a small job and leaving them as the old URL might be a potential source of confusion too.