### PR TITLE
KP-9717 Determine creator based on resourceCreator

### DIFF
--- a/harvester/metadata_parser.py
+++ b/harvester/metadata_parser.py
@@ -325,7 +325,10 @@ class RecordParser:
         actors = []
 
         actor_role_element_xpaths = {
-            "creator": ["//cmd:metadataInfo/cmd:metadataCreator"],
+            "creator": [
+                "//cmd:resourceCreationInfo/cmd:resourceCreatorPerson",
+                "//cmd:resourceCreationInfo/cmd:resourceCreatorOrganization",
+            ],
             "publisher": [
                 "//cmd:distributionInfo/cmd:licenceInfo/cmd:distributionRightsHolderPerson",
                 "//cmd:distributionInfo/cmd:licenceInfo/cmd:distributionRightsHolderOrganization",
@@ -363,9 +366,7 @@ class RecordParser:
                         raise RecordParsingError(str(err), self.pid)
 
         if sum(1 for actor in actors if "creator" in actor.roles) == 0:
-            raise RecordParsingError(
-                "No metadata creators (creator in Metax) found", self.pid
-            )
+            raise RecordParsingError("No dataset creators found", self.pid)
 
         publisher_actors = sum(1 for actor in actors if "publisher" in actor.roles)
         if publisher_actors == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -337,8 +337,8 @@ def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
                         "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
                     },
                     "person": {
-                        "email": "miina@example.com",
-                        "name": "Miina Metadataaja",
+                        "email": "diana@example.com",
+                        "name": "Diana Datankerääjä",
                     },
                     "roles": ["creator"],
                 },

--- a/tests/test_data/comedi_list_records_multiple.xml
+++ b/tests/test_data/comedi_list_records_multiple.xml
@@ -135,6 +135,29 @@
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
+              <resourceCreationInfo>
+                <resourceCreatorPerson>
+                  <role>resourceCreator</role>
+                  <personInfo>
+                    <surname xml:lang="en">Datankerääjä</surname>
+                    <givenName xml:lang="en">Diana</givenName>
+                    <sex>female</sex>
+                    <communicationInfo>
+                      <email>diana@example.com</email>
+                    </communicationInfo>
+                    <affiliation>
+                      <role>affiliation</role>
+                      <organizationInfo>
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                        <communicationInfo>
+                          <email>firstname.surname@helsinki.fi</email>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
+                  </personInfo>
+                </resourceCreatorPerson>
+              </resourceCreationInfo>
               <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
                 <resourceType>corpus</resourceType>
                 <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">
@@ -363,6 +386,29 @@
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
+              <resourceCreationInfo>
+                <resourceCreatorPerson>
+                  <role>resourceCreator</role>
+                  <personInfo>
+                    <surname xml:lang="en">Korpuksenluoja</surname>
+                    <givenName xml:lang="en">Kiira</givenName>
+                    <sex>female</sex>
+                    <communicationInfo>
+                      <email>kiira@example.com</email>
+                    </communicationInfo>
+                    <affiliation>
+                      <role>affiliation</role>
+                      <organizationInfo>
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                        <communicationInfo>
+                          <email>firstname.surname@helsinki.fi</email>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
+                  </personInfo>
+                </resourceCreatorPerson>
+              </resourceCreationInfo>
               <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
                 <resourceType>corpus</resourceType>
                 <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">
@@ -594,6 +640,29 @@
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
+              <resourceCreationInfo>
+                <resourceCreatorPerson>
+                  <role>resourceCreator</role>
+                  <personInfo>
+                    <surname xml:lang="en">Datankerääjä</surname>
+                    <givenName xml:lang="en">Diana</givenName>
+                    <sex>female</sex>
+                    <communicationInfo>
+                      <email>diana@example.com</email>
+                    </communicationInfo>
+                    <affiliation>
+                      <role>affiliation</role>
+                      <organizationInfo>
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                        <communicationInfo>
+                          <email>firstname.surname@helsinki.fi</email>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
+                  </personInfo>
+                </resourceCreatorPerson>
+              </resourceCreationInfo>
               <resourceDocumentationInfo ComponentId="clarin.eu:cr1:c_1355150532301">
                 <documentationUnstructured ComponentId="clarin.eu:cr1:c_1355150532302">
                   <role>documentation</role>
@@ -814,6 +883,29 @@
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
+              <resourceCreationInfo>
+                <resourceCreatorPerson>
+                  <role>resourceCreator</role>
+                  <personInfo>
+                    <surname xml:lang="en">Datankerääjä</surname>
+                    <givenName xml:lang="en">Diana</givenName>
+                    <sex>female</sex>
+                    <communicationInfo>
+                      <email>diana@example.com</email>
+                    </communicationInfo>
+                    <affiliation>
+                      <role>affiliation</role>
+                      <organizationInfo>
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                        <communicationInfo>
+                          <email>firstname.surname@helsinki.fi</email>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
+                  </personInfo>
+                </resourceCreatorPerson>
+              </resourceCreationInfo>
               <usageInfo ComponentId="clarin.eu:cr1:c_1353678848793">
                 <foreseenUseInfo ComponentId="clarin.eu:cr1:c_1353678848796">
                   <foreseenUse>humanUse</foreseenUse>
@@ -1011,6 +1103,29 @@
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
+              <resourceCreationInfo>
+                <resourceCreatorPerson>
+                  <role>resourceCreator</role>
+                  <personInfo>
+                    <surname xml:lang="en">Datankerääjä</surname>
+                    <givenName xml:lang="en">Diana</givenName>
+                    <sex>female</sex>
+                    <communicationInfo>
+                      <email>diana@example.com</email>
+                    </communicationInfo>
+                    <affiliation>
+                      <role>affiliation</role>
+                      <organizationInfo>
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                        <communicationInfo>
+                          <email>firstname.surname@helsinki.fi</email>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
+                  </personInfo>
+                </resourceCreatorPerson>
+              </resourceCreationInfo>
               <resourceDocumentationInfo ComponentId="clarin.eu:cr1:c_1355150532301">
                 <documentationUnstructured ComponentId="clarin.eu:cr1:c_1355150532302">
                   <role>documentation</role>

--- a/tests/test_data/comedi_list_records_single.xml
+++ b/tests/test_data/comedi_list_records_single.xml
@@ -136,6 +136,29 @@
                   </personInfo>
                 </metadataCreator>
               </metadataInfo>
+              <resourceCreationInfo>
+                <resourceCreatorPerson>
+                  <role>resourceCreator</role>
+                  <personInfo>
+                    <surname xml:lang="en">Datankerääjä</surname>
+                    <givenName xml:lang="en">Diana</givenName>
+                    <sex>female</sex>
+                    <communicationInfo>
+                      <email>diana@example.com</email>
+                    </communicationInfo>
+                    <affiliation>
+                      <role>affiliation</role>
+                      <organizationInfo>
+                        <organizationName xml:lang="en">University of Helsinki</organizationName>
+                        <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                        <communicationInfo>
+                          <email>firstname.surname@helsinki.fi</email>
+                        </communicationInfo>
+                      </organizationInfo>
+                    </affiliation>
+                  </personInfo>
+                </resourceCreatorPerson>
+              </resourceCreationInfo>
               <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
                 <resourceType>corpus</resourceType>
                 <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">

--- a/tests/test_data/kielipankki_record_sample.xml
+++ b/tests/test_data/kielipankki_record_sample.xml
@@ -131,6 +131,29 @@
               </personInfo>
             </metadataCreator>
           </metadataInfo>
+          <resourceCreationInfo>
+            <resourceCreatorPerson>
+              <role>resourceCreator</role>
+              <personInfo>
+                <surname xml:lang="en">Datankerääjä</surname>
+                <givenName xml:lang="en">Diana</givenName>
+                <sex>female</sex>
+                <communicationInfo>
+                  <email>diana@example.com</email>
+                </communicationInfo>
+                <affiliation>
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">University of Helsinki</organizationName>
+                    <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreatorPerson>
+          </resourceCreationInfo>
           <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
             <resourceType>corpus</resourceType>
             <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">

--- a/tests/test_data/kielipankki_record_sample_finclarin_affiliation.xml
+++ b/tests/test_data/kielipankki_record_sample_finclarin_affiliation.xml
@@ -106,6 +106,29 @@
               </personInfo>
             </metadataCreator>
           </metadataInfo>
+          <resourceCreationInfo>
+            <resourceCreatorPerson>
+              <role>resourceCreator</role>
+              <personInfo>
+                <surname xml:lang="en">Datankerääjä</surname>
+                <givenName xml:lang="en">Diana</givenName>
+                <sex>female</sex>
+                <communicationInfo>
+                  <email>diana@example.com</email>
+                </communicationInfo>
+                <affiliation>
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">University of Helsinki</organizationName>
+                    <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreatorPerson>
+          </resourceCreationInfo>
           <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
             <resourceType>corpus</resourceType>
             <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">

--- a/tests/test_data/kielipankki_record_sample_multiple_actors.xml
+++ b/tests/test_data/kielipankki_record_sample_multiple_actors.xml
@@ -233,6 +233,77 @@
               </personInfo>
             </metadataCreator>
           </metadataInfo>
+          <resourceCreationInfo>
+            <resourceCreatorPerson>
+              <role>resourceCreator</role>
+              <personInfo>
+                <surname xml:lang="en">Datankerääjä</surname>
+                <givenName xml:lang="en">Diana</givenName>
+                <sex>female</sex>
+                <communicationInfo>
+                  <email>diana@example.com</email>
+                </communicationInfo>
+                <affiliation>
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">University of Helsinki</organizationName>
+                    <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreatorPerson>
+            <resourceCreatorPerson>
+              <role>resourceCreator</role>
+              <personInfo ComponentId="clarin.eu:cr1:c_1349361150746">
+                <surname xml:lang="en">Affiliaattori</surname>
+                <givenName xml:lang="en">Amanda</givenName>
+                <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                  <email>aaffil@example.com</email>
+                </communicationInfo>
+                <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                  <role>affiliation</role>
+                  <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                    <organizationName xml:lang="en">Imaginary organization</organizationName>
+                    <organizationName xml:lang="fi">Kuvitteellinen organisaatio</organizationName>
+                    <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                      <email>imaginary@example.com</email>
+                      <url>http://www.imaginary.example</url>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreatorPerson>
+            <resourceCreatorPerson>
+              <role>resourceCreator</role>
+              <personInfo ComponentId="clarin.eu:cr1:c_1349361150746">
+                <surname xml:lang="fi">Aputoveri</surname>
+                <givenName xml:lang="fi">Aarne</givenName>
+                <sex>male</sex>
+                <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                  <email>aarne.aputoveri@example.com</email>
+                </communicationInfo>
+                <affiliation ComponentId="clarin.eu:cr1:c_1352813745462">
+                  <role>affiliation</role>
+                  <organizationInfo ComponentId="clarin.eu:cr1:c_1352813745461">
+                    <organizationName xml:lang="en">FIN-CLARIN</organizationName>
+                    <organizationShortName xml:lang="en">FIN-CLARIN</organizationShortName>
+                    <departmentName xml:lang="en">University of Helsinki</departmentName>
+                    <communicationInfo ComponentId="clarin.eu:cr1:c_1352813745460">
+                      <email>finclarin@helsinki.fi</email>
+                      <url>http://www.helsinki.fi/fin-clarin</url>
+                      <address>PO Box 24 (Unioninkatu 40)</address>
+                      <zipCode>00014</zipCode>
+                      <city>University of Helsinki</city>
+                      <country>Finland</country>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreatorPerson>
+          </resourceCreationInfo>
           <resourceDocumentationInfo ComponentId="clarin.eu:cr1:c_1355150532301">
             <documentationUnstructured ComponentId="clarin.eu:cr1:c_1355150532302">
               <role>documentation</role>

--- a/tests/test_data/kielipankki_record_sample_with_publisher_person.xml
+++ b/tests/test_data/kielipankki_record_sample_with_publisher_person.xml
@@ -181,6 +181,29 @@
               </personInfo>
             </metadataCreator>
           </metadataInfo>
+          <resourceCreationInfo>
+            <resourceCreatorPerson>
+              <role>resourceCreator</role>
+              <personInfo>
+                <surname xml:lang="en">Datankerääjä</surname>
+                <givenName xml:lang="en">Diana</givenName>
+                <sex>female</sex>
+                <communicationInfo>
+                  <email>diana@example.com</email>
+                </communicationInfo>
+                <affiliation>
+                  <role>affiliation</role>
+                  <organizationInfo>
+                    <organizationName xml:lang="en">University of Helsinki</organizationName>
+                    <organizationShortName xml:lang="en">UHEL</organizationShortName>
+                    <communicationInfo>
+                      <email>firstname.surname@helsinki.fi</email>
+                    </communicationInfo>
+                  </organizationInfo>
+                </affiliation>
+              </personInfo>
+            </resourceCreatorPerson>
+          </resourceCreationInfo>
           <corpusInfo ComponentId="clarin.eu:cr1:c_1355150532309">
             <resourceType>corpus</resourceType>
             <corpusMediaType ComponentId="clarin.eu:cr1:c_1355150532310">

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -84,7 +84,7 @@ def test_to_dict(basic_cmdi_record, dataset_pid, kielipankki_datacatalog_id):
         },
         "actors": [
             {
-                "person": {"email": "miina@example.com", "name": "Miina Metadataaja"},
+                "person": {"email": "diana@example.com", "name": "Diana Datankerääjä"},
                 "roles": ["creator"],
                 "organization": {
                     "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
@@ -347,7 +347,7 @@ def test_get_actors(basic_cmdi_record):
     assert len(actors) == 3
 
     assert {
-        "person": {"email": "miina@example.com", "name": "Miina Metadataaja"},
+        "person": {"email": "diana@example.com", "name": "Diana Datankerääjä"},
         "roles": ["creator"],
         "organization": {
             "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
@@ -383,18 +383,8 @@ def test_multiple_actors_for_same_role():
         {
             "roles": ["creator"],
             "person": {
-                "name": "Miina Metadataattori",
-                "email": "metadatamiina@example.com",
-            },
-            "organization": {
-                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/10089"
-            },
-        },
-        {
-            "roles": ["creator", "rights_holder"],
-            "person": {
-                "name": "Aarne Aputoveri",
-                "email": "aarne.aputoveri@example.com",
+                "name": "Diana Datankerääjä",
+                "email": "diana@example.com",
             },
             "organization": {
                 "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
@@ -412,6 +402,28 @@ def test_multiple_actors_for_same_role():
             "person": {
                 "email": "aaffil@example.com",
                 "name": "Amanda Affiliaattori",
+            },
+            "roles": [
+                "creator",
+            ],
+        },
+        {
+            "roles": ["creator", "rights_holder"],
+            "person": {
+                "name": "Aarne Aputoveri",
+                "email": "aarne.aputoveri@example.com",
+            },
+            "organization": {
+                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901"
+            },
+        },
+        {
+            "organization": {
+                "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+            },
+            "person": {
+                "email": "lauri@example.com",
+                "name": "Lauri Lisensoija",
             },
             "roles": [
                 "creator",


### PR DESCRIPTION
The old approach matched the spec created when initiating the project, but it is not what we want: creator in Metax should be the creator of the dataset, not creator of the associated metadata. The change also required adjusting many of the test files due to resourceCreators not having been present earlier.