### PR TITLE
KP-8075 More verbose Metax request logging

### DIFF
--- a/metax_api.py
+++ b/metax_api.py
@@ -59,7 +59,13 @@ class MetaxAPI:
             )
             response.raise_for_status()
             if method != "GET":
-                self.logger.info("Request succeeded. Method: %s, URL: %s", method, url)
+                if data:
+                    pid = data.get("persistent_identifier", "N/A")
+                else:
+                    pid = "N/A"
+                self.logger.info(
+                    "Request succeeded. Method: %s, URL: %s, PID: %s", method, url, pid
+                )
             if method == "DELETE":
                 return response
             return response.json() if response.status_code == 200 else None

--- a/metax_api.py
+++ b/metax_api.py
@@ -65,7 +65,11 @@ class MetaxAPI:
             return response.json() if response.status_code == 200 else None
         except HTTPError as error:
             self.logger.error(
-                "Request failed. Method: %s, URL: %s, Error: %s", method, url, error
+                "Request failed. Method: %s, URL: %s, Error: %s, Payload: %s",
+                method,
+                url,
+                error,
+                data,
             )
             raise
 


### PR DESCRIPTION
Previously, the logs kept of requests towards Metax API were not very useful for debugging. Now our PID is added to the log for all requests in which it is available at the time of making the request. This is especially important in case of POST requests made for records not previously in Metax, as for them we got no information about which record was added. The resulting log lines can look something like this:
```
2025-05-22 08:39:10,998 - logs/testing_metax_api_requests.log - INFO - Request succeeded. Method: PUT, URL: https://metax.demo.fairdata.fi/v3/datasets/67afeef0-fc85-41d2-b4f1-95d9ece68c7c, PID: urn:nbn:fi:lb-2014032610
2025-05-22 08:39:11,254 - logs/testing_metax_api_requests.log - INFO - Request succeeded. Method: POST, URL: https://metax.demo.fairdata.fi/v3/datasets, PID: urn:nbn:fi:lb-2014032611
```

If the PID is not available in the request payload (a faulty payload or a DELETE request with no payload), N/A is printed instead. This is not optimal for the deletions, but as deletions are rare and currently do not happen automatically, the bigger overhaul of the logging and/or data passing required for including the PID does not feel worth it.

For requests that do not succeed, the full payload is included in the log, meaning that they are quite verbose. Below, some of the longest fields have been truncated.
```
2025-05-22 08:39:15,795 - logs/testing_metax_api_requests.log - ERROR - Request failed. Method: POST, URL: https://metax.demo.fairdata.fi/v3/datasets, Error: 400 Client Error: Bad Request for url: https://metax.demo.fairdata.fi/v3/datasets, Payload: {'data_catalog': 'urn:nbn:fi:att:data-catalog-harvest-kielipankki', 'language': [{'url': 'http://lexvo.org/id/iso639-3/izh'}], 'field_of_science': [{'url': 'http://www.yso.fi/onto/okm-tieteenala/ta6121'}], 'persistent_identifier': 'urn:nbn:fi:lb-2014032614', 'title': {'en': 'Ingrian Corpus (UHLCS)', 'fi': 'Inkeroisen korpus (UHLCS)'}, 'description': {'en': '...'}, 'modified': '2024-12-05T12:09:30Z', 'created': '2024-04-30T00:00:00Z', 'access_rights': {'license': [{'url': 'http://uri.suomi.fi/codelist/fairdata/license/code/ClarinRES-1.0', 'custom_url': 'http://urn.fi/urn:nbn:fi:lb-20150304116'}], 'access_type': {'url': 'http://uri.suomi.fi/codelist/fairdata/access_type/code/restricted'}, 'restriction_grounds': [{'url': 'http://uri.suomi.fi/codelist/fairdata/restriction_grounds/code/other'}]}, 'actors': [{'roles': ['creator'], 'person': {'name': 'Manja Lehto', 'email': 'l_manja@hotmail.com'}, 'organization': None}, {'roles': ['curator'], 'person': {'name': 'User support at CSC - IT Center for Science Ltd. The Language Bank of Finland', 'email': 'kielipankki@csc.fi'}, 'organization': {'url': 'http://uri.suomi.fi/codelist/fairdata/organization/code/09206320'}}, ...], 'state': 'published'}
```

If there are a lot of failing requests, the logs will become a mess that is very difficult to read for a human. Fortunately, we _should_ never make requests that fail, and when we do, we are likely to want to know what exactly failed, so this feels justified.