### PR TITLE
KP-10352 Add CLI capable of deleting records from Metax

### DIFF
--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -14,8 +14,8 @@ from requests.exceptions import (
     HTTPError,
     RequestException,
 )
-import yaml
 
+from utils import cli_utils
 from harvester.metadata_parser import RecordParsingError
 from harvester.pmh_interface import PMH_API
 from metax_api import MetaxAPI
@@ -56,44 +56,6 @@ def last_harvest_date(log_file_path):
         return None
 
 
-def _config_from_file(config_file):
-    """
-    Read the YAML configuration from given file and return as a dict.
-
-    If the configuration file is malformed or missing some mandatory values, an
-    exception is raised.
-    """
-    try:
-        config = yaml.load(config_file, Loader=yaml.BaseLoader)
-    except yaml.YAMLError as e:
-        raise click.ClickException(
-            "Given configuration file does not seem to be in YAML fromat: "
-            f"{e}. See config/template.yml for valid configuration "
-            "file example."
-        )
-
-    if type(config) != dict:
-        raise click.ClickException(
-            "Unexpect configuration file structure. See config/template.yml for a "
-            "valid configuration file example."
-        )
-
-    expected_configuration_values = [
-        "metax_api_token",
-        "metax_base_url",
-        "metax_catalog_id",
-        "harvester_log_file",
-        "metax_api_log_file",
-    ]
-
-    for configuration_value in expected_configuration_values:
-        if configuration_value not in config:
-            raise click.ClickException(
-                f'Value for "{configuration_value}" not found in configuration file'
-            )
-    return config
-
-
 @click.command()
 @click.argument("config_file", type=click.File("r"), default="config/config.yml")
 @click.option(
@@ -114,7 +76,11 @@ def full_harvest(config_file, pause_between_records, automatic_delete):
 
     CONFIG_FILE Configuration for the harvesting. See config/template.yml for example.
     """
-    config = _config_from_file(config_file)
+    try:
+        config = cli_utils.config_from_file(config_file)
+    except cli_utils.ConfigurationError as err:
+        raise click.ClickException(str(err))
+
     source_api = PMH_API("https://clarino.uib.no/oai")
     destination_api = MetaxAPI(
         base_url=config["metax_base_url"],

--- a/metax_utils_cli.py
+++ b/metax_utils_cli.py
@@ -37,6 +37,11 @@ def delete_record(config_file, lb_pid):
     )
 
     metax_id = metax_api.record_id(lb_pid)
+
+    if not metax_id:
+        print(f"Record {lb_pid} not found in Metax")
+        return
+
     click.echo(f"Deleting record {lb_pid} (Metax identifier {metax_id}) from Metax")
     metax_api.delete_record(metax_id)
     click.echo("Record deleted")

--- a/metax_utils_cli.py
+++ b/metax_utils_cli.py
@@ -1,0 +1,46 @@
+import click
+
+from utils import cli_utils
+from metax_api import MetaxAPI
+
+
+@click.group
+def cli():
+    """
+    Helper functions for doing operations against Metax by hand
+    """
+
+
+@cli.command
+@click.argument("config_file", type=click.File("r"), default="config/config.yml")
+@click.argument("lb_pid", type=str)
+def delete_record(config_file, lb_pid):
+    """
+    Delete a single record from Metax.
+
+    \b
+    CONFIG_FILE Configuration for the harvesting. See config/template.yml for
+                example.
+    LB_PID      Identifier of the record to be deleted, e.g.
+                urn:nbn:fi:lb-1999010101
+    """
+    try:
+        config = cli_utils.config_from_file(config_file)
+    except cli_utils.ConfigurationError as err:
+        raise click.ClickException(str(err))
+
+    metax_api = MetaxAPI(
+        base_url=config["metax_base_url"],
+        catalog_id=config["metax_catalog_id"],
+        api_token=config["metax_api_token"],
+        api_request_log_path=config["metax_api_log_file"],
+    )
+
+    metax_id = metax_api.record_id(lb_pid)
+    click.echo(f"Deleting record {lb_pid} (Metax identifier {metax_id}) from Metax")
+    metax_api.delete_record(metax_id)
+    click.echo("Record deleted")
+
+
+if __name__ == "__main__":
+    cli()  # pylint: disable=no-value-for-parameter

--- a/tests/test_metax_utils_cli.py
+++ b/tests/test_metax_utils_cli.py
@@ -1,0 +1,33 @@
+import logging
+
+from click.testing import CliRunner
+import pytest
+
+import metax_utils_cli
+
+
+@pytest.mark.usefixtures(
+    "mock_cmdi_record_found_in_datacatalog",
+    "mock_requests_get_record",
+)
+def test_delete_record(
+    metax_dataset_id,
+    mock_delete_record,
+    dataset_pid,
+    run_cli,
+):
+    """
+    Test deleting a single record from Metax successfully.
+    """
+    result = run_cli(metax_utils_cli.delete_record, extra_args=[dataset_pid])
+
+    assert result.exit_code == 0
+
+    assert mock_delete_record.call_count == 2  # GET and DELETE both shown here
+    assert mock_delete_record.request_history[0].method == "GET"
+    assert mock_delete_record.request_history[1].method == "DELETE"
+    assert metax_dataset_id in mock_delete_record.request_history[1].path
+
+    assert f"Deleting record {dataset_pid}" in result.stdout
+    assert f"{metax_dataset_id}" in result.stdout
+    assert "Record deleted" in result.stdout

--- a/tests/test_metax_utils_cli.py
+++ b/tests/test_metax_utils_cli.py
@@ -31,3 +31,24 @@ def test_delete_record(
     assert f"Deleting record {dataset_pid}" in result.stdout
     assert f"{metax_dataset_id}" in result.stdout
     assert "Record deleted" in result.stdout
+
+
+@pytest.mark.usefixtures(
+    "mock_cmdi_record_not_found_in_datacatalog",
+)
+def test_delete_nonexistent_record(
+    mock_delete_record,
+    dataset_pid,
+    run_cli,
+):
+    """
+    Test deleting a single record from Metax successfully.
+    """
+    result = run_cli(metax_utils_cli.delete_record, extra_args=[dataset_pid])
+
+    assert result.exit_code == 0
+
+    assert mock_delete_record.call_count == 1
+    assert mock_delete_record.request_history[0].method == "GET"
+
+    assert f"Record {dataset_pid} not found in Metax" in result.stdout

--- a/utils/cli_utils.py
+++ b/utils/cli_utils.py
@@ -1,0 +1,43 @@
+import yaml
+
+
+def config_from_file(config_file):
+    """
+    Read the YAML configuration from given file and return as a dict.
+
+    If the configuration file is malformed or missing some mandatory values, an
+    exception is raised.
+    """
+    try:
+        config = yaml.load(config_file, Loader=yaml.BaseLoader)
+    except yaml.YAMLError as e:
+        raise ConfigurationError(
+            "Given configuration file does not seem to be in YAML fromat: "
+            f"{e}. See config/template.yml for valid configuration "
+            "file example."
+        )
+
+    if type(config) != dict:
+        raise ConfigurationError(
+            "Unexpect configuration file structure. See config/template.yml for a "
+            "valid configuration file example."
+        )
+
+    expected_configuration_values = [
+        "metax_api_token",
+        "metax_base_url",
+        "metax_catalog_id",
+        "harvester_log_file",
+        "metax_api_log_file",
+    ]
+
+    for configuration_value in expected_configuration_values:
+        if configuration_value not in config:
+            raise ConfigurationError(
+                f'Value for "{configuration_value}" not found in configuration file'
+            )
+    return config
+
+
+class ConfigurationError(Exception):
+    pass


### PR DESCRIPTION
To keep backwards compatibility, we don't want to mess with the metadata_harvester_cli too much (by e.g. adding new commands that would result in requiring specifying a command also for the normal harvest). A separate module was instead founded for manually running such one-off actions (I suppose this won't be our last need ever).

This involved some refactoring in terms of extracting the shared stuff for both CLIs and tests (done in [the first two commits](https://github.com/CSCfi/Kielipankki-Metax-bridge/compare/21c9b0c...0f752d38cb6c48226ea22f01b8ed1c621fa8adaa)) and then adding the new functionality ([the last two commits](https://github.com/CSCfi/Kielipankki-Metax-bridge/compare/0f752d38cb6c48226ea22f01b8ed1c621fa8adaa...77a09450283fc17e72d31ad38327209df8be60a0)).