### PR TITLE
KP-10529 Add option to save harvested records locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config/*
 !config/template.yml
 logs/*
 !logs/.gitkeep
+backups

--- a/config/template.yml
+++ b/config/template.yml
@@ -5,3 +5,6 @@ metax_catalog_id: urn:nbn:fi:att:data-catalog-harvest-kielipankki
 
 harvester_log_file: logs/harvester.log
 metax_api_log_file: logs/metax_api_requests.log
+
+save_records_locally: true
+save_destination_directory: backups/subdir

--- a/harvester/pmh_interface.py
+++ b/harvester/pmh_interface.py
@@ -21,7 +21,7 @@ class PMH_API:
         """
         self.sickle = Sickle(url)
 
-    def fetch_records(self, from_timestamp=None):
+    def fetch_records(self, from_timestamp=None, status="published"):
         """
         Fetch records that are new or updated since a date.
 
@@ -36,6 +36,7 @@ class PMH_API:
                     "from": from_timestamp,
                     "ignore_deleted": True,
                     "set": "FIN-CLARIN",
+                    "status": status,
                 }
             )
             for metadata_record in metadata_records:

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -198,6 +198,20 @@ def full_harvest(config_file, pause_between_records, automatic_delete):
             if not directory.exists():
                 directory.mkdir(parents=True)
 
+            expected_old_backup_filename = re.compile(r"lb-\d+\.xml")
+            for old_file in directory.iterdir():
+                if not (
+                    old_file.is_file
+                    and expected_old_backup_filename.match(old_file.name)
+                ):
+                    click.echo(
+                        f"Unexpected non-backup file {old_file} found in {directory}. "
+                        "Halting.",
+                        err=True,
+                    )
+                    raise click.Abort()
+                old_file.unlink()
+
             saved_records = 0
             for record in source_api.fetch_records(status=status):
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,6 +295,22 @@ def mock_corpus_pid_list_from_cmdi(
 
 
 @pytest.fixture
+def mock_list_records_no_in_progress(
+    shared_request_mocker,
+    kielipankki_api_url,
+    cmdi_no_records_xml,
+):
+    """
+    Mock a GET ListRecords for in progress records to return XML with no records.
+
+    :return: The corresponding metadata as a list of dicts, one dict per record
+    """
+    shared_request_mocker.get(
+        kielipankki_api_url + "&status=in-progress", text=cmdi_no_records_xml
+    )
+
+
+@pytest.fixture
 def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
     """
     Mock a GET ListRecords to return XML with a single record.
@@ -304,7 +320,9 @@ def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
     response_text = _get_file_as_string(
         "tests/test_data/comedi_list_records_single.xml"
     )
-    shared_request_mocker.get(kielipankki_api_url, text=response_text)
+    shared_request_mocker.get(
+        kielipankki_api_url + "&status=published", text=response_text
+    )
     yield [
         {
             "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",
@@ -364,6 +382,87 @@ def mock_list_records_single_record(shared_request_mocker, kielipankki_api_url):
                     },
                 },
             ],
+            "state": "published",
+        }
+    ]
+
+
+@pytest.fixture
+def mock_list_records_single_record_in_progress(
+    shared_request_mocker, kielipankki_api_url
+):
+    """
+    Mock a GET ListRecords for in progress records to return XML with a single record.
+
+    :return: The corresponding metadata as a list of dicts, one dict per record
+    """
+    response_text = _get_file_as_string(
+        "tests/test_data/comedi_list_records_single.xml"
+    )
+    shared_request_mocker.get(
+        kielipankki_api_url + "&status=in-progress", text=response_text
+    )
+    yield [
+        {
+            "data_catalog": "urn:nbn:fi:att:data-catalog-kielipankki",
+            "language": [{"url": "http://lexvo.org/id/iso639-3/fin"}],
+            "field_of_science": [
+                {"url": "http://www.yso.fi/onto/okm-tieteenala/ta6121"}
+            ],
+            "persistent_identifier": "urn:nbn:fi:lb-2017021609",
+            "title": {
+                "en": "Silva Kiuru's Time Expressions Corpus",
+                "fi": "Silva Kiurun ajanilmausaineisto",
+            },
+            "description": {
+                "en": "This corpus of time expressions has been compiled from literary works, translations, dialect texts as well as other texts. Format: word documents.",
+                "fi": "Tämä suomen kielen ajanilmauksia käsittävä aineisto on koottu kaunokirjallisten alkuperäisteosten, käännösten, murreaineistojen ja muiden tekstien pohjalta.",
+            },
+            "modified": "2024-06-19T07:38:46Z",
+            "created": "2022-09-02T00:00:00Z",
+            "access_rights": {
+                "license": [
+                    {
+                        "url": "http://uri.suomi.fi/codelist/fairdata/license/code/undernegotiation"
+                    }
+                ],
+                "access_type": {
+                    "url": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"
+                },
+            },
+            "actors": [
+                {
+                    "organization": {
+                        "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+                    },
+                    "person": {
+                        "email": "diana@example.com",
+                        "name": "Diana Datankerääjä",
+                    },
+                    "roles": ["creator"],
+                },
+                {
+                    "organization": {
+                        "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+                    },
+                    "roles": [
+                        "publisher",
+                        "rights_holder",
+                    ],
+                },
+                {
+                    "roles": ["curator"],
+                    "person": {
+                        "name": "Kiia Kontakti",
+                        "email": "kiia@example.com",
+                    },
+                    "organization": {
+                        "url": "http://uri.suomi.fi/codelist/fairdata/organization/code/01901",
+                    },
+                },
+            ],
+            # NB: this is hard-coded in the metadata parser: it cannot determine it from
+            # the record, nor are we expecting to send unpublished records to Metax.
             "state": "published",
         }
     ]
@@ -552,6 +651,7 @@ def basic_configuration(
             "metax_catalog_id": "urn:nbn:fi:att:data-catalog-kielipankki",
             "harvester_log_file": str(default_test_log_file_path),
             "metax_api_log_file": str(default_metax_api_log_file_path),
+            "save_records_locally": False,
         }
     )
 

--- a/utils/cli_utils.py
+++ b/utils/cli_utils.py
@@ -1,4 +1,5 @@
 import yaml
+from pathlib import Path
 
 
 def config_from_file(config_file):
@@ -9,7 +10,7 @@ def config_from_file(config_file):
     exception is raised.
     """
     try:
-        config = yaml.load(config_file, Loader=yaml.BaseLoader)
+        config = yaml.load(config_file, Loader=yaml.SafeLoader)
     except yaml.YAMLError as e:
         raise ConfigurationError(
             "Given configuration file does not seem to be in YAML fromat: "
@@ -29,6 +30,7 @@ def config_from_file(config_file):
         "metax_catalog_id",
         "harvester_log_file",
         "metax_api_log_file",
+        "save_records_locally",
     ]
 
     for configuration_value in expected_configuration_values:
@@ -36,6 +38,24 @@ def config_from_file(config_file):
             raise ConfigurationError(
                 f'Value for "{configuration_value}" not found in configuration file'
             )
+
+    if config["save_records_locally"]:
+        if "save_destination_directory" not in config:
+            raise ConfigurationError(
+                "When save_records_locally is set, save_destination_directory must be provided."
+            )
+        config["save_destination_directory"] = Path(
+            config["save_destination_directory"]
+        )
+
+        if (
+            config["save_destination_directory"].exists()
+            and not config["save_destination_directory"].is_dir
+        ):
+            raise ConfigurationError(
+                "Given save_destination_directory exists and is not a directory"
+            )
+
     return config
 
 


### PR DESCRIPTION
The records are saved in individual XML files under a given directory. To enable parsing the boolean value for whether to save the records, the parsing of the configuration file has now been boosted to use `SafeLoader`.

We want to save all records, not only the published corpora, so the saving is done in a separate loop instead of as part of the normal bridge loop. The records whose saving has failed are also reported separately.

If local backup is enabled, all records are always redownloaded instead of only the records changed since the last run. This ensures that runnin the bridge once without backing up enabled will not leave gaps in the backup.

The tests must now account for the difference between requests for published or unpublished records towards COMEDI. Because most of the tests don't create backups, most COMEDI request fixtures can stay ignorant of different statuses, but the ones involved in testing backing up the two types of records must now have the status.