### PR TITLE
KP-11142 Log successful backup to file, not stdout

### DIFF
--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -208,11 +208,15 @@ def full_harvest(config_file, pause_between_records, automatic_delete):
                     old_file.is_file
                     and expected_old_backup_filename.match(old_file.name)
                 ):
-                    click.echo(
+                    message = (
                         f"Unexpected non-backup file {old_file} found in {directory}. "
-                        "Halting.",
+                        "Halting."
+                    )
+                    click.echo(
+                        message,
                         err=True,
                     )
+                    logger_harvester.error(message)
                     raise click.Abort()
                 old_file.unlink()
 
@@ -221,12 +225,16 @@ def full_harvest(config_file, pause_between_records, automatic_delete):
                 try:
                     save_record_to_file(record, directory)
                 except RecordParsingError as err:
-                    click.echo(
+                    message = (
                         f"A local backup for record {err.identifier} could not be "
-                        f"created: {err.message}",
+                        f"created: {err.message}"
+                    )
+                    click.echo(
+                        message,
                         err=True,
                     )
                     unsaved_records += 1
+                    logger_harvester.error(message)
                 else:
                     saved_records += 1
             logger_harvester.info(

--- a/metadata_harvester_cli.py
+++ b/metadata_harvester_cli.py
@@ -229,7 +229,9 @@ def full_harvest(config_file, pause_between_records, automatic_delete):
                     unsaved_records += 1
                 else:
                     saved_records += 1
-            click.echo(f"Saved {saved_records} {status} records to {directory}")
+            logger_harvester.info(
+                f"Saved %d %s records to %s", saved_records, status, directory
+            )
 
     if automatic_delete:
         delete_records(source_api, destination_api)


### PR DESCRIPTION
Our cronjobs send all stdout via email, so we want to produce no lines there on a successful run. The errors are still printed to stdout, so they will be sent via email. The new lines apprea in the log file like this:
```
2026-02-10 08:46:43,230 - INFO - Started
2026-02-10 08:47:24,924 - INFO - Success, 12 records harvested since 2026-01-16T17:37:21Z
2026-02-10 08:48:09,254 - INFO - Saved 811 published records to backups/published
2026-02-10 08:48:09,764 - INFO - Saved 11 in-progress records to backups/in_progress
2026-02-10 08:51:06,516 - INFO - Started
2026-02-10 08:51:06,824 - INFO - Success, 0 records harvested since 2026-02-10T08:46:43Z
2026-02-10 08:51:46,591 - INFO - Saved 811 published records to backups/published
2026-02-10 08:51:47,110 - INFO - Saved 11 in-progress records to backups/in_progress
```
and do not affect determining the timestamp of the last successful harvest.