### PR TITLE
KP-11527 Hard-delete records from Metax

### DIFF
--- a/metax_api.py
+++ b/metax_api.py
@@ -164,13 +164,18 @@ class MetaxAPI:
         endpoint = f"datasets/{record_id}"
         return self._make_request("PUT", endpoint, data=data)
 
-    def delete_record(self, record_id):
+    def delete_record(self, record_id, flush=False):
         """
         Delete a dataset record from Metax.
         :param record_id: the record UUID in Metax
+        :param flush: When set to True, the record is fully purged instead of just being
+                      marked as deleted
         """
+        params = {}
+        if flush:
+            params["flush"] = True
         endpoint = f"datasets/{record_id}"
-        return self._make_request("DELETE", endpoint)
+        return self._make_request("DELETE", endpoint, params)
 
     @property
     def datacatalog_record_pids(self):

--- a/metax_api.py
+++ b/metax_api.py
@@ -79,17 +79,35 @@ class MetaxAPI:
             )
             raise
 
-    def record_id(self, pid):
+    def record(self, pid, include_removed=False):
+        """
+        Get the full Metax record for a given Language Bank PID
+
+        :param dataset pid: the persistent identifier of the record
+        :param include_removed: whether records marked deleted should be searched too
+        :return: the record in Metax or None
+        """
+        params = {
+            "data_catalog__id": self.catalog_id,
+            "persistent_identifier": pid,
+            "include_removed": include_removed,
+        }
+        endpoint = "datasets"
+        result = self._make_request("GET", endpoint, params)
+        return result["results"][0] if result["count"] == 1 else None
+
+    def record_id(self, pid, include_removed=False):
         """
         Get the UUID of a dataset record from Metax if such record exists.
 
         :param dataset pid: the persistent identifier of the record
+        :param include_removed: whether records marked deleted should be searched too
         :return: the record identifier in Metax or None
         """
-        params = {"data_catalog__id": self.catalog_id, "persistent_identifier": pid}
-        endpoint = "datasets"
-        result = self._make_request("GET", endpoint, params)
-        return result["results"][0]["id"] if result["count"] == 1 else None
+        record = self.record(pid, include_removed)
+        if not record:
+            return None
+        return record["id"]
 
     def send_record(self, record):
         """

--- a/metax_utils_cli.py
+++ b/metax_utils_cli.py
@@ -23,7 +23,17 @@ def cli():
 @cli.command
 @click.argument("config_file", type=click.File("r"), default="config/config.yml")
 @click.argument("lb_pid", type=str)
-def delete_record(config_file, lb_pid):
+@click.option(
+    "--hard",
+    "hard_delete",
+    is_flag=True,
+    default=False,
+    help=(
+        "Perform a hard delete that will erase the leftover record with deleted "
+        "state (corresponds to flush=True in Metax)"
+    ),
+)
+def delete_record(config_file, lb_pid, hard_delete):
     """
     Delete a single record from Metax.
 
@@ -45,14 +55,34 @@ def delete_record(config_file, lb_pid):
         api_request_log_path=config["metax_api_log_file"],
     )
 
-    metax_id = metax_api.record_id(lb_pid)
+    metax_record = metax_api.record(lb_pid, include_removed=True)
 
-    if not metax_id:
+    if not metax_record:
         print(f"Record {lb_pid} not found in Metax")
         return
 
-    click.echo(f"Deleting record {lb_pid} (Metax identifier {metax_id}) from Metax")
-    metax_api.delete_record(metax_id)
+    metax_record_title = " / ".join(
+        f'"{metax_record["title"][lang]}" ({lang})' for lang in metax_record["title"]
+    )
+    metax_record_identifier = metax_record["id"]
+
+    click.confirm(
+        f"You are about to delete {metax_record_title} with PID {lb_pid} and Metax "
+        f"identifier {metax_record_identifier} from Metax. Are you sure?",
+        abort=True,
+    )
+
+    if hard_delete:
+        click.confirm(
+            "Due to providing --hard, the record will be fully erased from Metax and "
+            'cannot be retrieved by providing "include_removed=true". Proceed?',
+            abort=True,
+        )
+
+    click.echo(
+        f"Deleting record {lb_pid} (Metax identifier {metax_record_identifier}) from Metax"
+    )
+    metax_api.delete_record(metax_record_identifier, flush=hard_delete)
     click.echo("Record deleted")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -667,7 +667,9 @@ def run_cli(basic_configuration):
     converted.
     """
 
-    def _run_cli(cli_function, configuration_file_path=None, extra_args=None):
+    def _run_cli(
+        cli_function, configuration_file_path=None, extra_args=None, input=None
+    ):
         if configuration_file_path is None:
             configuration_file_path = basic_configuration
 
@@ -676,6 +678,6 @@ def run_cli(basic_configuration):
             extra_args = []
 
         runner = CliRunner(mix_stderr=False)
-        return runner.invoke(cli_function, required_args + extra_args)
+        return runner.invoke(cli_function, required_args + extra_args, input=input)
 
     return _run_cli

--- a/tests/test_metax_utils_cli.py
+++ b/tests/test_metax_utils_cli.py
@@ -19,7 +19,7 @@ def test_delete_record(
     """
     Test deleting a single record from Metax successfully.
     """
-    result = run_cli(metax_utils_cli.delete_record, extra_args=[dataset_pid])
+    result = run_cli(metax_utils_cli.delete_record, extra_args=[dataset_pid], input="y")
 
     assert result.exit_code == 0
 


### PR DESCRIPTION
Sometimes there are records that need to be completely purged from Metax (e.g. ones that have been marked as deleted back when the export was still done from META-SHARE), but we did not have a tool for that. Having it included in the CLI tools avoids the need to do those (rare) operations by manually editing the request parameters by hand.

Additional verification steps were added so that it's easy for the user to verify that the record that is being deleted is indeed the correct one, and that e.g. accidental up-entering won't cause deletions without manual confirmation.